### PR TITLE
feat: Brand 등록 API

### DIFF
--- a/src/main/java/org/boot/growup/source/seller/ImageStore.java
+++ b/src/main/java/org/boot/growup/source/seller/ImageStore.java
@@ -1,0 +1,23 @@
+package org.boot.growup.source.seller;
+
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class ImageStore {
+
+    public String createStoreFileName(String originalFilename) {
+        // 서버에 저장하는 파일명
+        String uuid = UUID.randomUUID().toString(); // uuid만 하면 qwe-qwe-qwe-123 같이 생성됨.
+        String ext = extractExt(originalFilename); // 확장자명 추출
+
+        return uuid + "." + ext;
+    }
+
+    public String extractExt(String originalFilename) {
+        int pos = originalFilename.lastIndexOf(".");
+        return originalFilename.substring(pos+1); // 확장자명
+    }
+}
+

--- a/src/main/java/org/boot/growup/source/seller/application/BrandApplication.java
+++ b/src/main/java/org/boot/growup/source/seller/application/BrandApplication.java
@@ -1,0 +1,31 @@
+package org.boot.growup.source.seller.application;
+
+import lombok.RequiredArgsConstructor;
+import org.boot.growup.source.seller.dto.BrandPostDTO;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.service.BrandImageService;
+import org.boot.growup.source.seller.service.BrandService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BrandApplication {
+    private final BrandService brandService;
+    private final BrandImageService brandImageService;
+
+
+    @Transactional
+    public void registerBrandWithBrandImages(BrandPostDTO brandPostDTO, List<MultipartFile> brandImageFiles) {
+        // TODO : 현재 유저가 seller인지 확인 및 seller 가져오기.
+
+        // TODO : 해당 seller가 brand를 갖고 있는지 검사.
+
+        Brand brand = brandService.registerBrand(brandPostDTO);
+        brandImageService.saveBrandImages(brandImageFiles, brand);
+    }
+}

--- a/src/main/java/org/boot/growup/source/seller/constant/AuthorityStatus.java
+++ b/src/main/java/org/boot/growup/source/seller/constant/AuthorityStatus.java
@@ -1,0 +1,5 @@
+package org.boot.growup.source.seller.constant;
+
+public enum AuthorityStatus {
+    APPROVED, DENIED, PENDING
+}

--- a/src/main/java/org/boot/growup/source/seller/controller/BrandController.java
+++ b/src/main/java/org/boot/growup/source/seller/controller/BrandController.java
@@ -1,0 +1,27 @@
+package org.boot.growup.source.seller.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.boot.growup.source.seller.application.BrandApplication;
+import org.boot.growup.source.seller.dto.BrandPostDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/sellers/brand")
+@RequiredArgsConstructor
+public class BrandController {
+
+    private final BrandApplication brandApplication;
+
+    @PostMapping
+    public ResponseEntity<?> registerBrand(
+            @RequestPart(value = "brandImages") List<MultipartFile> brandImageFiles,
+            @RequestPart(value = "form") BrandPostDTO brandPostDTO
+    ) {
+        brandApplication.registerBrandWithBrandImages(brandPostDTO, brandImageFiles);
+        return ResponseEntity.ok("등록 성공");
+    }
+}

--- a/src/main/java/org/boot/growup/source/seller/dto/BrandPostDTO.java
+++ b/src/main/java/org/boot/growup/source/seller/dto/BrandPostDTO.java
@@ -1,0 +1,11 @@
+package org.boot.growup.source.seller.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BrandPostDTO {
+    private String name;
+    private String description;
+}

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/Brand.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/Brand.java
@@ -1,0 +1,71 @@
+package org.boot.growup.source.seller.persist.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.source.seller.dto.BrandPostDTO;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "brand")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Brand {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String description;
+    @Enumerated(EnumType.STRING)
+    private AuthorityStatus authorityStatus;
+    private int likes;
+
+    @OneToOne
+    @JoinColumn(name = "seller_id")
+    private Seller seller;
+
+    public static Brand from(BrandPostDTO brandPostDTO) {
+        return Brand.builder()
+                .name(brandPostDTO.getName())
+                .description(brandPostDTO.getDescription())
+                .build();
+    }
+
+    /*
+        허가 상태 변경 (authorityStatus)
+     */
+
+    public void approve(){
+        this.authorityStatus = AuthorityStatus.APPROVED;
+    }
+
+    public void deny(){
+        this.authorityStatus = AuthorityStatus.DENIED;
+    }
+
+    public void pending(){
+        this.authorityStatus = AuthorityStatus.PENDING;
+    }
+
+    /*
+        판매자(대표자) 설정
+     */
+
+    public void designateSeller(Seller seller){
+        this.seller = seller;
+    }
+
+    /*
+        좋아요 수 설정
+     */
+
+    public void initLikesCnt(){
+        this.likes = 0;
+    }
+}

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/BrandImage.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/BrandImage.java
@@ -1,0 +1,31 @@
+package org.boot.growup.source.seller.persist.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "brand_image")
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrandImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String originalImageName;
+    private String path;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "brand_id")
+    private Brand brand;
+
+    public void designateBrand(Brand brand) {
+        this.brand = brand;
+    }
+}

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/Seller.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/Seller.java
@@ -1,0 +1,33 @@
+package org.boot.growup.source.seller.persist.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "seller")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Seller {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String cpEmail;
+    private String cpPassword;
+    private String phoneNumber;
+    private String epName;
+    private String cpCode;
+    private String cpName;
+    private String cpAddress;
+    private int netProceeds;
+
+    @OneToOne(mappedBy = "seller")
+    private Brand brand;
+
+}

--- a/src/main/java/org/boot/growup/source/seller/persist/repository/BrandImageRepository.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/repository/BrandImageRepository.java
@@ -1,0 +1,7 @@
+package org.boot.growup.source.seller.persist.repository;
+
+import org.boot.growup.source.seller.persist.entity.BrandImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BrandImageRepository extends JpaRepository<BrandImage, Long> {
+}

--- a/src/main/java/org/boot/growup/source/seller/service/BrandImageService.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandImageService.java
@@ -1,0 +1,80 @@
+package org.boot.growup.source.seller.service;
+
+import lombok.RequiredArgsConstructor;
+import org.boot.growup.source.seller.ImageStore;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.BrandImage;
+import org.boot.growup.source.seller.persist.repository.BrandImageRepository;
+import org.boot.growup.source.seller.persist.repository.BrandRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BrandImageService {
+    private final BrandImageRepository brandImageRepository;
+    private final ImageStore imageStore;
+
+//    private final AmazonS3Client amazonS3Client;
+//
+//    @Value("${cloud.aws.s3.bucket}") // TODO: 이미지 수정해주기
+//    private String bucket;
+//    @Value("${cloud.aws.region.static}")
+//    private String region;
+
+//   TODO: @Value("${file.dir.cafeteria}")
+    private String BrandImageDir = "/Users/gnues/Documents/grow/Images/brandImages/";
+
+//   TODO: file:
+//    dir:
+//    cafeteria: /Users/gnues/Documents/grow/Images/brandImages/
+
+    public String getFullPath(String filename){
+        return BrandImageDir + filename;
+    }
+
+    @Transactional
+    public void saveBrandImages(List<MultipartFile> brandImageFiles, Brand brand) {
+//      TODO : S3설정  String fileName = menuImage.getOriginalFilename();
+//        String fileUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
+//        ObjectMetadata metadata= new ObjectMetadata();
+//        metadata.setContentType(menuImage.getContentType());
+//        metadata.setContentLength(menuImage.getSize());
+//        amazonS3Client.putObject(bucket, fileName, menuImage.getInputStream(), metadata);
+//        log.info("fileUrl={}",fileUrl);
+
+        for(MultipartFile multipartFile : brandImageFiles){
+            if(!multipartFile.isEmpty()){
+                BrandImage uploadImage = storeImage(multipartFile);
+                uploadImage.designateBrand(brand);
+                brandImageRepository.save(uploadImage);
+            }
+        }
+    }
+
+    public BrandImage storeImage(MultipartFile multipartFile) {
+        if(multipartFile.isEmpty()){
+            throw new IllegalStateException("이미지가 없습니다.");
+        }
+
+        String originalFilename = multipartFile.getOriginalFilename(); // 원래 이름
+        String storeFilename = imageStore.createStoreFileName(originalFilename); // 저장된 이름
+
+        try {
+            multipartFile.transferTo(new File(getFullPath(storeFilename))); // 디렉토리에 파일 넘어가서 만들어짐.
+        }catch (Exception e){
+            throw new IllegalStateException("transferTo failed"); // TODO: 수정필요
+        }
+
+        return BrandImage.builder()
+                .originalImageName(originalFilename)
+                .path(storeFilename)
+                .build();
+    }
+}

--- a/src/main/java/org/boot/growup/source/seller/service/BrandService.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandService.java
@@ -1,0 +1,32 @@
+package org.boot.growup.source.seller.service;
+
+import lombok.RequiredArgsConstructor;
+import org.boot.growup.source.seller.dto.BrandPostDTO;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.repository.BrandRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BrandService {
+    private final BrandRepository brandRepository;
+
+    // seller 객체 넘겨주기.
+    @Transactional
+    public Brand registerBrand(BrandPostDTO brandPostDTO) {
+
+        if (brandRepository.findByName(brandPostDTO.getName()).isPresent()) {
+            throw new IllegalStateException("해당 브랜드명은 이미 존재합니다.");
+        }
+
+        Brand brand = Brand.from(brandPostDTO);
+        brand.pending();
+        brand.initLikesCnt();
+        // TODO : brand.designateSeller(seller); 판매자 설정.
+        brandRepository.save(brand);
+
+        return brand;
+    }
+}


### PR DESCRIPTION
## 변경사항
### AS-IS
- Brand, Seller, BrandImage 엔티티, 레포지토리, 서비스, 컨트롤러, 어플리케이션 생성
- BrandController에서 BrandApplication을 사용하고, BrandApplication에서는 BrandImageService, BrandService를 사용함.

### TO-BE
- BrandController에 대한 테스트는 완성하지 않음.

## 테스트
- [ ] 테스트 코드
- [ ] API 테스트