### PR TITLE
Feature/seller/brand : 판매자 브랜드 수정 및 판매자 브랜드 조회 기능 생성 및 테스트

### DIFF
--- a/src/main/java/org/boot/growup/common/ImageStore.java
+++ b/src/main/java/org/boot/growup/common/ImageStore.java
@@ -1,4 +1,4 @@
-package org.boot.growup.source.seller;
+package org.boot.growup.common;
 
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/org/boot/growup/common/SecurityConfig.java
+++ b/src/main/java/org/boot/growup/common/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/customers/email/**", "/customers/oauth/**").permitAll()
                         .requestMatchers("/sellers/**").permitAll()
+                        .requestMatchers("/v3/**", "/swagger-ui/**").permitAll() // swagger 설정
                         .requestMatchers("/customers/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/org/boot/growup/common/SecurityConfig.java
+++ b/src/main/java/org/boot/growup/common/SecurityConfig.java
@@ -2,14 +2,12 @@ package org.boot.growup.common;
 
 import lombok.RequiredArgsConstructor;
 import org.boot.growup.common.jwt.JwtAuthenticationFilter;
-import org.boot.growup.common.jwt.JwtTokenProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -37,7 +35,8 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/customers/email/**", "/customers/oauth/**").permitAll()
-                        .requestMatchers("/customers/**").hasRole("CUSTOMER")
+                        .requestMatchers("/sellers/**").permitAll()
+                        .requestMatchers("/customers/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/org/boot/growup/common/enumerate/AuthorityStatus.java
+++ b/src/main/java/org/boot/growup/common/enumerate/AuthorityStatus.java
@@ -1,4 +1,4 @@
-package org.boot.growup.source.seller.constant;
+package org.boot.growup.common.enumerate;
 
 public enum AuthorityStatus {
     APPROVED, DENIED, PENDING

--- a/src/main/java/org/boot/growup/common/error/ErrorCode.java
+++ b/src/main/java/org/boot/growup/common/error/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, 500, false, "유저를 찾지 못했습니다."),
 
     /* Brand 관련 */
-    BRAND_NAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,404, false, "해당 브랜드명은 이미 존재합니다.");
+    BRAND_NAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,404, false, "해당 브랜드명은 이미 존재합니다."),
+    BRAND_BY_SELLER_NOT_FOUND(HttpStatus.BAD_REQUEST, 404, false, "해당 셀러ID의 브랜드는 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/org/boot/growup/common/error/ErrorCode.java
+++ b/src/main/java/org/boot/growup/common/error/ErrorCode.java
@@ -20,8 +20,10 @@ public enum ErrorCode {
 
     /* Validation */
     INVALID_VALUE(HttpStatus.BAD_REQUEST, 400, false, "잘못된 입력값입니다."),
-    USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, 500, false, "유저를 찾지 못했습니다.");
+    USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, 500, false, "유저를 찾지 못했습니다."),
 
+    /* Brand 관련 */
+    BRAND_NAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,404, false, "해당 브랜드명은 이미 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/org/boot/growup/source/seller/application/BrandApplication.java
+++ b/src/main/java/org/boot/growup/source/seller/application/BrandApplication.java
@@ -1,7 +1,7 @@
 package org.boot.growup.source.seller.application;
 
 import lombok.RequiredArgsConstructor;
-import org.boot.growup.source.seller.dto.BrandPostDTO;
+import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 import org.boot.growup.source.seller.persist.entity.Brand;
 import org.boot.growup.source.seller.service.BrandImageService;
 import org.boot.growup.source.seller.service.BrandService;
@@ -20,12 +20,12 @@ public class BrandApplication {
 
 
     @Transactional
-    public void registerBrandWithBrandImages(BrandPostDTO brandPostDTO, List<MultipartFile> brandImageFiles) {
+    public void registerBrandWithBrandImages(RegisterBrandRequestDTO registerBrandRequestDTO, List<MultipartFile> brandImageFiles) {
         // TODO : 현재 유저가 seller인지 확인 및 seller 가져오기.
 
         // TODO : 해당 seller가 brand를 갖고 있는지 검사.
 
-        Brand brand = brandService.registerBrand(brandPostDTO);
+        Brand brand = brandService.registerBrand(registerBrandRequestDTO);
         brandImageService.saveBrandImages(brandImageFiles, brand);
     }
 }

--- a/src/main/java/org/boot/growup/source/seller/application/BrandApplication.java
+++ b/src/main/java/org/boot/growup/source/seller/application/BrandApplication.java
@@ -2,7 +2,11 @@ package org.boot.growup.source.seller.application;
 
 import lombok.RequiredArgsConstructor;
 import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
+import org.boot.growup.source.seller.dto.response.ReadSellerBrandResponseDTO;
 import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.BrandImage;
+import org.boot.growup.source.seller.persist.entity.Seller;
+import org.boot.growup.source.seller.persist.repository.SellerRepository;
 import org.boot.growup.source.seller.service.BrandImageService;
 import org.boot.growup.source.seller.service.BrandService;
 import org.springframework.stereotype.Service;
@@ -17,15 +21,53 @@ import java.util.List;
 public class BrandApplication {
     private final BrandService brandService;
     private final BrandImageService brandImageService;
+    private final SellerRepository sellerRepository;
 
-
+    /*
+        브랜드 및 브랜드 이미지 등록
+     */
     @Transactional
     public void registerBrandWithBrandImages(RegisterBrandRequestDTO registerBrandRequestDTO, List<MultipartFile> brandImageFiles) {
         // TODO : 현재 유저가 seller인지 확인 및 seller 가져오기.
 
         // TODO : 해당 seller가 brand를 갖고 있는지 검사.
+        Seller seller = sellerRepository.findById(1L).get();
 
-        Brand brand = brandService.registerBrand(registerBrandRequestDTO);
+        Brand brand = brandService.registerBrand(registerBrandRequestDTO, seller);
         brandImageService.saveBrandImages(brandImageFiles, brand);
+    }
+
+    /*
+        판매자의 브랜드 조회
+     */
+    public ReadSellerBrandResponseDTO readSellerBrand() {
+        // TODO : 현재 유저가 seller인지 확인 및 seller 가져오기
+
+        // TODO : 해당 seller가 brand를 갖고 있는지 검사.
+        Long sellerId = 1L;
+        Brand brand = brandService.readBrandBySellerId(sellerId);
+        List<BrandImage> brandImages = brandImageService.readBrandImages(brand.getId());
+
+        return ReadSellerBrandResponseDTO.builder()
+                .name(brand.getName())
+                .description(brand.getDescription())
+                .brandImages(
+                        brandImages.stream().map(ReadSellerBrandResponseDTO.BrandImageDTO::from).toList()
+                )
+                .build();
+    }
+
+    /*
+        판매자의 브랜드 및 이미지 수정
+     */
+    @Transactional
+    public void updateBrand(RegisterBrandRequestDTO registerBrandRequestDTO, List<MultipartFile> brandImageFiles) {
+        // TODO : 현재 유저가 seller인지 확인 및 seller 가져오기.
+
+        // TODO : 해당 seller가 brand를 갖고 있는지 검사.
+        Seller seller = sellerRepository.findById(1L).get();
+
+        Brand brand = brandService.updateBrand(registerBrandRequestDTO, seller);
+        brandImageService.updateBrandImages(brandImageFiles, brand);
     }
 }

--- a/src/main/java/org/boot/growup/source/seller/controller/BrandController.java
+++ b/src/main/java/org/boot/growup/source/seller/controller/BrandController.java
@@ -1,9 +1,9 @@
 package org.boot.growup.source.seller.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.boot.growup.common.constant.BaseResponse;
 import org.boot.growup.source.seller.application.BrandApplication;
-import org.boot.growup.source.seller.dto.BrandPostDTO;
-import org.springframework.http.ResponseEntity;
+import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,11 +17,11 @@ public class BrandController {
     private final BrandApplication brandApplication;
 
     @PostMapping
-    public ResponseEntity<?> registerBrand(
+    public BaseResponse<String> registerBrand(
             @RequestPart(value = "brandImages") List<MultipartFile> brandImageFiles,
-            @RequestPart(value = "form") BrandPostDTO brandPostDTO
+            @RequestPart(value = "form") RegisterBrandRequestDTO registerBrandRequestDTO
     ) {
-        brandApplication.registerBrandWithBrandImages(brandPostDTO, brandImageFiles);
-        return ResponseEntity.ok("등록 성공");
+        brandApplication.registerBrandWithBrandImages(registerBrandRequestDTO, brandImageFiles);
+        return new BaseResponse<>("등록 성공");
     }
 }

--- a/src/main/java/org/boot/growup/source/seller/controller/BrandController.java
+++ b/src/main/java/org/boot/growup/source/seller/controller/BrandController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.boot.growup.common.constant.BaseResponse;
 import org.boot.growup.source.seller.application.BrandApplication;
 import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
+import org.boot.growup.source.seller.dto.response.ReadSellerBrandResponseDTO;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,6 +17,12 @@ public class BrandController {
 
     private final BrandApplication brandApplication;
 
+    /**
+     * 현재 판매자의 브랜드 등록 요청
+     * @param brandImageFiles
+     * @param registerBrandRequestDTO
+     * @return
+     */
     @PostMapping
     public BaseResponse<String> registerBrand(
             @RequestPart(value = "brandImages") List<MultipartFile> brandImageFiles,
@@ -24,4 +31,34 @@ public class BrandController {
         brandApplication.registerBrandWithBrandImages(registerBrandRequestDTO, brandImageFiles);
         return new BaseResponse<>("등록 성공");
     }
+
+    /**
+     * 현재 판매자의 브랜드 정보 조회
+     * @return ReadSellerBrandResponseDTO
+     */
+    @GetMapping
+    public BaseResponse<ReadSellerBrandResponseDTO> readSellerBrand(){
+        var res = brandApplication.readSellerBrand();
+        return new BaseResponse<>(res);
+    }
+
+    /**
+     * 현재 판매자의 브랜드 정보 수정 및 허가요청
+     * @param brandImageFiles
+     * @param registerBrandRequestDTO
+     * @return
+     */
+    @PatchMapping
+    public BaseResponse<String> updateBrand(
+            @RequestPart(value = "brandImages") List<MultipartFile> brandImageFiles,
+            @RequestPart(value = "form") RegisterBrandRequestDTO registerBrandRequestDTO
+    ){
+        brandApplication.updateBrand(registerBrandRequestDTO, brandImageFiles);
+        return new BaseResponse<>("수정 성공");
+    }
+
+
+
+
+
 }

--- a/src/main/java/org/boot/growup/source/seller/dto/request/RegisterBrandRequestDTO.java
+++ b/src/main/java/org/boot/growup/source/seller/dto/request/RegisterBrandRequestDTO.java
@@ -1,11 +1,11 @@
-package org.boot.growup.source.seller.dto;
+package org.boot.growup.source.seller.dto.request;
 
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
-public class BrandPostDTO {
+public class RegisterBrandRequestDTO {
     private String name;
     private String description;
 }

--- a/src/main/java/org/boot/growup/source/seller/dto/response/ReadSellerBrandResponseDTO.java
+++ b/src/main/java/org/boot/growup/source/seller/dto/response/ReadSellerBrandResponseDTO.java
@@ -1,0 +1,29 @@
+package org.boot.growup.source.seller.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import org.boot.growup.source.seller.persist.entity.BrandImage;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ReadSellerBrandResponseDTO {
+    private String name;
+    private String description;
+    private List<BrandImageDTO> brandImages;
+
+    @Data
+    @Builder
+    public static class BrandImageDTO {
+        private String path;
+        private String originalImageName;
+
+        public static BrandImageDTO from(BrandImage brandImage) {
+            return BrandImageDTO.builder()
+                    .path(brandImage.getPath())
+                    .originalImageName(brandImage.getOriginalImageName())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/Brand.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/Brand.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.boot.growup.source.seller.constant.AuthorityStatus;
-import org.boot.growup.source.seller.dto.BrandPostDTO;
+import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 
 @Entity
 @Getter
@@ -15,25 +15,32 @@ import org.boot.growup.source.seller.dto.BrandPostDTO;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Brand {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "brand_id", nullable = false)
     private Long id;
 
+    @Column(nullable = false, length = 25)
     private String name;
+
+    @Column(nullable = false, length = 500)
     private String description;
+
+    @Column(name = "authority_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private AuthorityStatus authorityStatus;
+
+    @Column(nullable = false)
     private int likes;
 
     @OneToOne
     @JoinColumn(name = "seller_id")
     private Seller seller;
 
-    public static Brand from(BrandPostDTO brandPostDTO) {
+    public static Brand from(RegisterBrandRequestDTO registerBrandRequestDTO) {
         return Brand.builder()
-                .name(brandPostDTO.getName())
-                .description(brandPostDTO.getDescription())
+                .name(registerBrandRequestDTO.getName())
+                .description(registerBrandRequestDTO.getDescription())
                 .build();
     }
 

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/Brand.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/Brand.java
@@ -75,4 +75,12 @@ public class Brand {
     public void initLikesCnt(){
         this.likes = 0;
     }
+
+    /*
+        brand명 및 상세 설명 수정
+     */
+    public void updateBrandInfo(String name, String description){
+        this.name = name;
+        this.description = description;
+    }
 }

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/Brand.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/Brand.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.common.enumerate.AuthorityStatus;
 import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 
 @Entity

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/BrandImage.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/BrandImage.java
@@ -13,12 +13,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BrandImage {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "brand_image_id", nullable = false)
     private Long id;
 
+    @Column(nullable = false)
     private String originalImageName;
+
+    @Column(nullable = false)
     private String path;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/Product.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/Product.java
@@ -11,7 +11,6 @@ import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.*;
 
 @Entity
 @Table(name = "product")
@@ -39,7 +38,7 @@ public class Product {
     private LocalDateTime deletedAt;
 
     private String status;
-    private String authorityStatus = "대기";
+    private String authorityStatus;
 
     @ManyToOne
     @JoinColumn(name = "sub_category_id")

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/Seller.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/Seller.java
@@ -24,7 +24,7 @@ public class Seller {
     @Column(nullable = false, length = 60)
     private String cpPassword;
 
-    @Column(nullable = false, length = 11)
+    @Column(nullable = false, length = 14)
     private String phoneNumber;
 
     @Column(nullable = false, length = 10)

--- a/src/main/java/org/boot/growup/source/seller/persist/entity/Seller.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/entity/Seller.java
@@ -13,18 +13,33 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Seller {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "seller_id", nullable = false)
     private Long id;
 
+    @Column(nullable = false, length = 300)
     private String cpEmail;
+
+    @Column(nullable = false, length = 60)
     private String cpPassword;
+
+    @Column(nullable = false, length = 11)
     private String phoneNumber;
+
+    @Column(nullable = false, length = 10)
     private String epName;
+
+    @Column(nullable = false, length = 20)
     private String cpCode;
+
+    @Column(nullable = false, length = 50)
     private String cpName;
+
+    @Column(nullable = false, length = 100)
     private String cpAddress;
+
+    @Column(nullable = true)
     private int netProceeds;
 
     @OneToOne(mappedBy = "seller")

--- a/src/main/java/org/boot/growup/source/seller/persist/repository/BrandImageRepository.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/repository/BrandImageRepository.java
@@ -3,5 +3,9 @@ package org.boot.growup.source.seller.persist.repository;
 import org.boot.growup.source.seller.persist.entity.BrandImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BrandImageRepository extends JpaRepository<BrandImage, Long> {
+    List<BrandImage> findBrandImageByBrand_Id(Long id);
+    void deleteBrandImageByBrand_Id(Long id);
 }

--- a/src/main/java/org/boot/growup/source/seller/persist/repository/BrandRepository.java
+++ b/src/main/java/org/boot/growup/source/seller/persist/repository/BrandRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface BrandRepository extends JpaRepository<Brand, Long> {
     Optional<Brand> findByName(String name);
+    Optional<Brand> findBySeller_Id(Long id);
 }

--- a/src/main/java/org/boot/growup/source/seller/service/BrandImageService.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandImageService.java
@@ -1,80 +1,12 @@
 package org.boot.growup.source.seller.service;
 
-import lombok.RequiredArgsConstructor;
-import org.boot.growup.source.seller.ImageStore;
 import org.boot.growup.source.seller.persist.entity.Brand;
-import org.boot.growup.source.seller.persist.entity.BrandImage;
-import org.boot.growup.source.seller.persist.repository.BrandImageRepository;
-import org.boot.growup.source.seller.persist.repository.BrandRepository;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class BrandImageService {
-    private final BrandImageRepository brandImageRepository;
-    private final ImageStore imageStore;
-
-//    private final AmazonS3Client amazonS3Client;
-//
-//    @Value("${cloud.aws.s3.bucket}") // TODO: 이미지 수정해주기
-//    private String bucket;
-//    @Value("${cloud.aws.region.static}")
-//    private String region;
-
-//   TODO: @Value("${file.dir.cafeteria}")
-    private String BrandImageDir = "/Users/gnues/Documents/grow/Images/brandImages/";
-
-//   TODO: file:
-//    dir:
-//    cafeteria: /Users/gnues/Documents/grow/Images/brandImages/
-
-    public String getFullPath(String filename){
-        return BrandImageDir + filename;
-    }
-
-    @Transactional
-    public void saveBrandImages(List<MultipartFile> brandImageFiles, Brand brand) {
-//      TODO : S3설정  String fileName = menuImage.getOriginalFilename();
-//        String fileUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
-//        ObjectMetadata metadata= new ObjectMetadata();
-//        metadata.setContentType(menuImage.getContentType());
-//        metadata.setContentLength(menuImage.getSize());
-//        amazonS3Client.putObject(bucket, fileName, menuImage.getInputStream(), metadata);
-//        log.info("fileUrl={}",fileUrl);
-
-        for(MultipartFile multipartFile : brandImageFiles){
-            if(!multipartFile.isEmpty()){
-                BrandImage uploadImage = storeImage(multipartFile);
-                uploadImage.designateBrand(brand);
-                brandImageRepository.save(uploadImage);
-            }
-        }
-    }
-
-    public BrandImage storeImage(MultipartFile multipartFile) {
-        if(multipartFile.isEmpty()){
-            throw new IllegalStateException("이미지가 없습니다.");
-        }
-
-        String originalFilename = multipartFile.getOriginalFilename(); // 원래 이름
-        String storeFilename = imageStore.createStoreFileName(originalFilename); // 저장된 이름
-
-        try {
-            multipartFile.transferTo(new File(getFullPath(storeFilename))); // 디렉토리에 파일 넘어가서 만들어짐.
-        }catch (Exception e){
-            throw new IllegalStateException("transferTo failed"); // TODO: 수정필요
-        }
-
-        return BrandImage.builder()
-                .originalImageName(originalFilename)
-                .path(storeFilename)
-                .build();
-    }
+public interface BrandImageService {
+    void saveBrandImages(List<MultipartFile> brandImageFiles, Brand brand);
 }

--- a/src/main/java/org/boot/growup/source/seller/service/BrandImageService.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandImageService.java
@@ -1,6 +1,7 @@
 package org.boot.growup.source.seller.service;
 
 import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.BrandImage;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,4 +10,6 @@ import java.util.List;
 @Service
 public interface BrandImageService {
     void saveBrandImages(List<MultipartFile> brandImageFiles, Brand brand);
+    List<BrandImage> readBrandImages(Long id);
+    void updateBrandImages(List<MultipartFile> brandImageFiles, Brand brand);
 }

--- a/src/main/java/org/boot/growup/source/seller/service/BrandImageServiceImpl.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandImageServiceImpl.java
@@ -1,0 +1,78 @@
+package org.boot.growup.source.seller.service;
+
+import lombok.RequiredArgsConstructor;
+import org.boot.growup.common.ImageStore;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.BrandImage;
+import org.boot.growup.source.seller.persist.repository.BrandImageRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BrandImageServiceImpl implements BrandImageService {
+    private final BrandImageRepository brandImageRepository;
+    private final ImageStore imageStore;
+
+//    private final AmazonS3Client amazonS3Client;
+//
+//    @Value("${cloud.aws.s3.bucket}") // TODO: 이미지 수정해주기
+//    private String bucket;
+//    @Value("${cloud.aws.region.static}")
+//    private String region;
+
+//   TODO: @Value("${file.dir.cafeteria}")
+    private String BrandImageDir = "/Users/gnues/Documents/grow/Images/brandImages/";
+
+//   TODO: file:
+//    dir:
+//    cafeteria: /Users/gnues/Documents/grow/Images/brandImages/
+
+    private String getFullPath(String filename){
+        return BrandImageDir + filename;
+    }
+
+    @Transactional
+    public void saveBrandImages(List<MultipartFile> brandImageFiles, Brand brand) {
+//      TODO : S3설정  String fileName = menuImage.getOriginalFilename();
+//        String fileUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
+//        ObjectMetadata metadata= new ObjectMetadata();
+//        metadata.setContentType(menuImage.getContentType());
+//        metadata.setContentLength(menuImage.getSize());
+//        amazonS3Client.putObject(bucket, fileName, menuImage.getInputStream(), metadata);
+//        log.info("fileUrl={}",fileUrl);
+
+        for(MultipartFile multipartFile : brandImageFiles){
+            if(!multipartFile.isEmpty()){
+                BrandImage uploadImage = storeImage(multipartFile);
+                uploadImage.designateBrand(brand);
+                brandImageRepository.save(uploadImage);
+            }
+        }
+    }
+
+    private BrandImage storeImage(MultipartFile multipartFile) {
+        if(multipartFile.isEmpty()){
+            throw new IllegalStateException("이미지가 없습니다.");
+        }
+
+        String originalFilename = multipartFile.getOriginalFilename(); // 원래 이름
+        String storeFilename = imageStore.createStoreFileName(originalFilename); // 저장된 이름
+
+        try {
+            multipartFile.transferTo(new File(getFullPath(storeFilename))); // 디렉토리에 파일 넘어가서 만들어짐.
+        }catch (Exception e){
+            throw new IllegalStateException("transferTo failed"); // TODO: 수정필요
+        }
+
+        return BrandImage.builder()
+                .originalImageName(originalFilename)
+                .path(storeFilename)
+                .build();
+    }
+}

--- a/src/main/java/org/boot/growup/source/seller/service/BrandImageServiceImpl.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandImageServiceImpl.java
@@ -38,6 +38,7 @@ public class BrandImageServiceImpl implements BrandImageService {
     }
 
     @Transactional
+    @Override
     public void saveBrandImages(List<MultipartFile> brandImageFiles, Brand brand) {
 //      TODO : S3설정  String fileName = menuImage.getOriginalFilename();
 //        String fileUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fileName;
@@ -47,6 +48,27 @@ public class BrandImageServiceImpl implements BrandImageService {
 //        amazonS3Client.putObject(bucket, fileName, menuImage.getInputStream(), metadata);
 //        log.info("fileUrl={}",fileUrl);
 
+        for(MultipartFile multipartFile : brandImageFiles){
+            if(!multipartFile.isEmpty()){
+                BrandImage uploadImage = storeImage(multipartFile);
+                uploadImage.designateBrand(brand);
+                brandImageRepository.save(uploadImage);
+            }
+        }
+    }
+
+    @Override
+    public List<BrandImage> readBrandImages(Long id) {
+        return brandImageRepository.findBrandImageByBrand_Id(id);
+    }
+
+    @Transactional
+    @Override
+    public void updateBrandImages(List<MultipartFile> brandImageFiles, Brand brand) {
+        // 1. 현재 등록된 브랜드 이미지를 지움.
+        brandImageRepository.deleteBrandImageByBrand_Id(brand.getId());
+
+        // 2. 해당 브랜드에 이미지를 새로 등록함.
         for(MultipartFile multipartFile : brandImageFiles){
             if(!multipartFile.isEmpty()){
                 BrandImage uploadImage = storeImage(multipartFile);

--- a/src/main/java/org/boot/growup/source/seller/service/BrandService.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandService.java
@@ -1,33 +1,10 @@
 package org.boot.growup.source.seller.service;
 
-import lombok.RequiredArgsConstructor;
-import org.boot.growup.source.seller.dto.BrandPostDTO;
+import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 import org.boot.growup.source.seller.persist.entity.Brand;
-import org.boot.growup.source.seller.persist.repository.BrandRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
-@Transactional(readOnly = true)
-public class BrandService {
-    private final BrandRepository brandRepository;
-
-    // seller 객체 넘겨주기.
-    @Transactional
-    public Brand registerBrand(BrandPostDTO brandPostDTO) {
-
-        if (brandRepository.findByName(brandPostDTO.getName()).isPresent()) {
-            throw new IllegalStateException("해당 브랜드명은 이미 존재합니다.");
-        }
-
-        Brand brand = Brand.from(brandPostDTO);
-
-        brand.pending();
-        brand.initLikesCnt();
-        // TODO : brand.designateSeller(seller); 판매자 설정.
-        brandRepository.save(brand);
-
-        return brand;
-    }
+public interface BrandService {
+    Brand registerBrand(RegisterBrandRequestDTO registerBrandRequestDTO);
 }

--- a/src/main/java/org/boot/growup/source/seller/service/BrandService.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandService.java
@@ -2,9 +2,12 @@ package org.boot.growup.source.seller.service;
 
 import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.Seller;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface BrandService {
-    Brand registerBrand(RegisterBrandRequestDTO registerBrandRequestDTO);
+    Brand registerBrand(RegisterBrandRequestDTO registerBrandRequestDTO, Seller seller);
+    Brand readBrandBySellerId(Long sellerId);
+    Brand updateBrand(RegisterBrandRequestDTO registerBrandRequestDTO, Seller seller);
 }

--- a/src/main/java/org/boot/growup/source/seller/service/BrandServiceImpl.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandServiceImpl.java
@@ -1,0 +1,35 @@
+package org.boot.growup.source.seller.service;
+
+import lombok.RequiredArgsConstructor;
+import org.boot.growup.common.constant.BaseException;
+import org.boot.growup.common.error.ErrorCode;
+import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.repository.BrandRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BrandServiceImpl implements BrandService {
+    private final BrandRepository brandRepository;
+
+    // seller 객체 넘겨주기.
+    @Transactional
+    public Brand registerBrand(RegisterBrandRequestDTO registerBrandRequestDTO) {
+
+        if (brandRepository.findByName(registerBrandRequestDTO.getName()).isPresent()) {
+            throw new BaseException(ErrorCode.BRAND_NAME_ALREADY_EXISTS);
+        }
+
+        Brand brand = Brand.from(registerBrandRequestDTO);
+
+        brand.pending();
+        brand.initLikesCnt();
+        // TODO : brand.designateSeller(seller); 판매자 설정.
+        brandRepository.save(brand);
+
+        return brand;
+    }
+}

--- a/src/main/java/org/boot/growup/source/seller/service/BrandServiceImpl.java
+++ b/src/main/java/org/boot/growup/source/seller/service/BrandServiceImpl.java
@@ -5,6 +5,7 @@ import org.boot.growup.common.constant.BaseException;
 import org.boot.growup.common.error.ErrorCode;
 import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.Seller;
 import org.boot.growup.source.seller.persist.repository.BrandRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +18,8 @@ public class BrandServiceImpl implements BrandService {
 
     // seller 객체 넘겨주기.
     @Transactional
-    public Brand registerBrand(RegisterBrandRequestDTO registerBrandRequestDTO) {
+    @Override
+    public Brand registerBrand(RegisterBrandRequestDTO registerBrandRequestDTO, Seller seller) {
 
         if (brandRepository.findByName(registerBrandRequestDTO.getName()).isPresent()) {
             throw new BaseException(ErrorCode.BRAND_NAME_ALREADY_EXISTS);
@@ -27,8 +29,28 @@ public class BrandServiceImpl implements BrandService {
 
         brand.pending();
         brand.initLikesCnt();
-        // TODO : brand.designateSeller(seller); 판매자 설정.
+        brand.designateSeller(seller); // 판매자 설정.
         brandRepository.save(brand);
+
+        return brand;
+    }
+
+    @Override
+    public Brand readBrandBySellerId(Long sellerId) {
+        return brandRepository.findBySeller_Id(sellerId).orElseThrow(
+                () -> new BaseException(ErrorCode.BRAND_BY_SELLER_NOT_FOUND)
+        );
+    }
+
+    @Transactional
+    @Override
+    public Brand updateBrand(RegisterBrandRequestDTO registerBrandRequestDTO, Seller seller) {
+        Brand brand = brandRepository.findBySeller_Id(seller.getId()).orElseThrow(
+                () -> new BaseException(ErrorCode.BRAND_BY_SELLER_NOT_FOUND)
+        );
+
+        brand.pending(); // 대기 상태로 변경.
+        brand.updateBrandInfo(registerBrandRequestDTO.getName(), registerBrandRequestDTO.getDescription());
 
         return brand;
     }

--- a/src/test/java/org/boot/growup/source/seller/application/BrandApplicationTest.java
+++ b/src/test/java/org/boot/growup/source/seller/application/BrandApplicationTest.java
@@ -1,0 +1,150 @@
+package org.boot.growup.source.seller.application;
+
+import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
+import org.boot.growup.source.seller.dto.response.ReadSellerBrandResponseDTO;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.BrandImage;
+import org.boot.growup.source.seller.persist.entity.Seller;
+import org.boot.growup.source.seller.persist.repository.SellerRepository;
+import org.boot.growup.source.seller.service.BrandImageService;
+import org.boot.growup.source.seller.service.BrandServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BrandApplicationTest {
+
+
+    @InjectMocks
+    private BrandApplication brandApplication;
+
+    @Mock
+    private BrandServiceImpl brandService;
+
+    @Mock
+    private BrandImageService brandImageService;
+
+    @Mock
+    private SellerRepository sellerRepository;
+
+    RegisterBrandRequestDTO registerBrandRequestDTO1;
+    RegisterBrandRequestDTO registerBrandRequestDTO2;
+
+    Brand brand1;
+    BrandImage brandImage1;
+    BrandImage brandImage2;
+    Seller seller;
+
+
+    @BeforeEach
+    void setUp() {
+        registerBrandRequestDTO1 = RegisterBrandRequestDTO.builder()
+                .name("라퍼지스토어")
+                .description("라퍼지스토어(LAFUDGESTORE)는 다양한 사람들이 일상에서 편안하게 사용할 수 있는 제품을 전개합니다. 새롭게 변화되는 소재와 실루엣, 일상에 자연스레 스며드는 제품을 제작하여 지속적인 실속형 소비의 가치를 실천합니다.")
+                .build();
+        registerBrandRequestDTO2 = RegisterBrandRequestDTO.builder()
+                .name("드로우핏")
+                .description("드로우핏(DRAW FIT)은 핏과 착용감을 중요하게 여기며 컨템포러리&모던 룩을 지향하는 브랜드입니다. 뛰어난 퀄리티의 좋은 소재를 다양하게 구성해 바느질까지 세심하게 신경 써서 완성하고 고유의 핏과 무드를 머금은 웨어러블한 디자인의 아이템을 합리적인 가격으로 소개합니다.")
+                .build();
+
+        brand1 = Brand.builder()
+                .name("라퍼지스토어")
+                .description("라퍼지스토어(LAFUDGESTORE)는 다양한 사람들이 일상에서 편안하게 사용할 수 있는 제품을 전개합니다. 새롭게 변화되는 소재와 실루엣, 일상에 자연스레 스며드는 제품을 제작하여 지속적인 실속형 소비의 가치를 실천합니다.")
+                .authorityStatus(AuthorityStatus.PENDING)
+                .likes(0)
+                .build();
+
+        brandImage1 = BrandImage.builder()
+                .path("aws/s3/path/qyrwqirakfasfk1.jpg")
+                .originalImageName("lafudge1.jpg")
+                .build();
+        brandImage2 = BrandImage.builder()
+                .path("aws/s3/path/qyrwqirakfasfk2.jpg")
+                .originalImageName("lafudge2.jpg")
+                .build();
+        seller = Seller.builder()
+                .cpEmail("lafudgestore@naver.com")
+                .cpPassword("password1234")
+                .phoneNumber("010-7797-8841") // 대표 전화번호
+                .epName("손준호") // 대표자명
+                .cpName("(주)슬로우스탠다드") // 상호명
+                .cpCode("178-86-01188") // 10자리의 사업자 등록번호
+                .cpAddress("경기도 의정부시 오목로225번길 94, 씨와이파크 (민락동)") // 사업장 소재지(회사주소)
+                .netProceeds(1000)
+                .build();
+    }
+
+    @Test
+    public void registerBrandWithBrandImages_Default_Success() {
+        //given
+        MockMultipartFile file1 = new MockMultipartFile("file", "test1.jpg", "image/jpeg", "test image content 1".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile("file", "test2.jpg", "image/jpeg", "test image content 2".getBytes());
+        given(brandService.registerBrand(registerBrandRequestDTO1, seller)).willReturn(brand1);
+        given(sellerRepository.findById(1L)).willReturn(Optional.of(seller));
+        List<MultipartFile> mockFiles = List.of(file1, file2);
+
+        //when
+        brandApplication.registerBrandWithBrandImages(registerBrandRequestDTO1, mockFiles);
+
+        //then
+        verify(brandService).registerBrand(registerBrandRequestDTO1, seller);
+        verify(brandImageService).saveBrandImages(mockFiles, brand1);
+    }
+
+    @Test
+    public void readSellerBrand_Default_Success() {
+        //given
+        List<BrandImage> brandImages = List.of(brandImage1, brandImage2);
+        given(brandService.readBrandBySellerId(1L)).willReturn(brand1);
+        given(brandImageService.readBrandImages(brand1.getId())).willReturn(brandImages);
+        ReadSellerBrandResponseDTO dto = ReadSellerBrandResponseDTO.builder()
+                .name(brand1.getName())
+                .description(brand1.getDescription())
+                .brandImages(
+                        brandImages.stream().map(ReadSellerBrandResponseDTO.BrandImageDTO::from).toList()
+                )
+                .build();
+
+
+        //when
+        ReadSellerBrandResponseDTO res = brandApplication.readSellerBrand();
+
+        //then
+        assertNotNull(res);
+        assertEquals(dto, res);
+    }
+
+    @Test
+    public void updateBrand_Default_Success() {
+        //given
+        MockMultipartFile file1 = new MockMultipartFile("file", "test1.jpg", "image/jpeg", "test image content 1".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile("file", "test2.jpg", "image/jpeg", "test image content 2".getBytes());
+        given(brandService.updateBrand(registerBrandRequestDTO2, seller)).willReturn(brand1);
+        given(sellerRepository.findById(1L)).willReturn(Optional.of(seller));
+        List<MultipartFile> mockFiles = List.of(file1, file2);
+
+        //when
+        brandApplication.updateBrand(registerBrandRequestDTO2, mockFiles);
+
+        //then
+        verify(brandService).updateBrand(registerBrandRequestDTO2, seller);
+        verify(brandImageService).updateBrandImages(mockFiles, brand1);
+    }
+}

--- a/src/test/java/org/boot/growup/source/seller/application/BrandApplicationTest.java
+++ b/src/test/java/org/boot/growup/source/seller/application/BrandApplicationTest.java
@@ -1,6 +1,6 @@
 package org.boot.growup.source.seller.application;
 
-import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.common.enumerate.AuthorityStatus;
 import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 import org.boot.growup.source.seller.dto.response.ReadSellerBrandResponseDTO;
 import org.boot.growup.source.seller.persist.entity.Brand;

--- a/src/test/java/org/boot/growup/source/seller/persist/repository/BrandImageRepositoryTest.java
+++ b/src/test/java/org/boot/growup/source/seller/persist/repository/BrandImageRepositoryTest.java
@@ -1,0 +1,118 @@
+package org.boot.growup.source.seller.persist.repository;
+
+import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.BrandImage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+@ActiveProfiles("test") // 테스트 시 dev profile을 활성화시킴.
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 기본 생성된 datasource 빈을 사용함.
+class BrandImageRepositoryTest {
+    
+    @Autowired
+    private BrandImageRepository brandImageRepository;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    Brand brand;
+    BrandImage brandImage1;
+    BrandImage brandImage2;
+    BrandImage brandImage3;
+
+    @BeforeEach
+    void setUp() {
+        brandRepository.deleteAll();
+        brandImageRepository.deleteAll();
+
+        brand = Brand.builder()
+                .name("라퍼지스토어")
+                .description("라퍼지스토어(LAFUDGESTORE)는 다양한 사람들이 일상에서 편안하게 사용할 수 있는 제품을 전개합니다. 새롭게 변화되는 소재와 실루엣, 일상에 자연스레 스며드는 제품을 제작하여 지속적인 실속형 소비의 가치를 실천합니다.")
+                .authorityStatus(AuthorityStatus.PENDING)
+                .likes(0)
+                .build();
+
+        brandRepository.save(brand);
+
+        brandImage1 = BrandImage.builder()
+                .originalImageName("HelloWorld.jpg")
+                .path("https://bucket.s3.region.amazonaws.com/HelloWorld.jpg")
+                .brand(brand)
+                .build();
+
+        brandImage2 = BrandImage.builder()
+                .originalImageName("HelloWorld2.jpg")
+                .path("https://bucket.s3.region.amazonaws.com/HelloWorld2.jpg")
+                .brand(brand)
+                .build();
+
+        brandImage3 = BrandImage.builder()
+                .originalImageName("HelloWorld3.jpg")
+                .path("https://bucket.s3.region.amazonaws.com/HelloWorld3.jpg")
+                .brand(brand)
+                .build();
+    }
+
+    @Test
+    public void brandImageInsert_Default_Success() {
+        //given
+        BrandImage brandImage = BrandImage.builder()
+                .originalImageName("HelloWorld.jpg")
+                .path("https://bucket.s3.region.amazonaws.com/HelloWorld.jpg")
+                .brand(brand)
+                .build();
+
+        //when
+        BrandImage brandImageDB = brandImageRepository.save(brandImage);
+        
+        //then
+        assertNotNull(brandImageDB);
+        assertEquals("HelloWorld.jpg", brandImageDB.getOriginalImageName());
+        assertEquals(brandImage.getPath(), brandImageDB.getPath());
+        assertEquals(brand, brandImageDB.getBrand());
+        assertEquals(1L, brandImageDB.getId());
+    }
+
+    @Test
+    public void findBrandImageByBrand_Id_Default_Success(){
+        //given
+        brandImageRepository.save(brandImage1);
+        brandImageRepository.save(brandImage2);
+        brandImageRepository.save(brandImage3);
+
+        //when
+        List<BrandImage> brandImages = brandImageRepository.findBrandImageByBrand_Id(brand.getId());
+
+        //then
+        assertNotNull(brandImages);
+        assertEquals(3, brandImages.size());
+    }
+
+    @Test
+    public void deleteBrandImageByBrand_Id_Default_Success(){
+        //given
+        brandImageRepository.save(brandImage1);
+        brandImageRepository.save(brandImage2);
+        brandImageRepository.save(brandImage3);
+
+        //when
+        brandImageRepository.deleteBrandImageByBrand_Id(brand.getId());
+
+        //then
+        assertEquals(0, brandImageRepository.findBrandImageByBrand_Id(1L).size());
+    }
+
+}

--- a/src/test/java/org/boot/growup/source/seller/persist/repository/BrandImageRepositoryTest.java
+++ b/src/test/java/org/boot/growup/source/seller/persist/repository/BrandImageRepositoryTest.java
@@ -1,6 +1,6 @@
 package org.boot.growup.source.seller.persist.repository;
 
-import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.common.enumerate.AuthorityStatus;
 import org.boot.growup.source.seller.persist.entity.Brand;
 import org.boot.growup.source.seller.persist.entity.BrandImage;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/org/boot/growup/source/seller/persist/repository/BrandRepositoryTest.java
+++ b/src/test/java/org/boot/growup/source/seller/persist/repository/BrandRepositoryTest.java
@@ -1,6 +1,6 @@
 package org.boot.growup.source.seller.persist.repository;
 
-import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.common.enumerate.AuthorityStatus;
 import org.boot.growup.source.seller.persist.entity.Brand;
 import org.boot.growup.source.seller.persist.entity.Seller;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/boot/growup/source/seller/persist/repository/BrandRepositoryTest.java
+++ b/src/test/java/org/boot/growup/source/seller/persist/repository/BrandRepositoryTest.java
@@ -1,0 +1,83 @@
+package org.boot.growup.source.seller.persist.repository;
+
+import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.Seller;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+@ActiveProfiles("test") // 테스트 시 dev profile을 활성화시킴.
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 기본 생성된 datasource 빈을 사용함.
+class BrandRepositoryTest {
+    
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+    
+    @Test
+    public void save_success() {
+        //given
+        Brand brand = Brand.builder()
+                .name("라퍼지스토어")
+                .description("라퍼지스토어(LAFUDGESTORE)는 다양한 사람들이 일상에서 편안하게 사용할 수 있는 제품을 전개합니다. 새롭게 변화되는 소재와 실루엣, 일상에 자연스레 스며드는 제품을 제작하여 지속적인 실속형 소비의 가치를 실천합니다.")
+                .authorityStatus(AuthorityStatus.PENDING)
+                .likes(0)
+                .build();
+
+        //when
+        Brand brandDB = brandRepository.save(brand);
+        
+        //then
+        assertNotNull(brandDB);
+        assertEquals(brand.getName(), brandDB.getName());
+        assertEquals(brand.getDescription(), brandDB.getDescription());
+        assertEquals(brand.getLikes(), brandDB.getLikes());
+        assertEquals(1L, brandDB.getId());
+    }
+
+    @Test
+    public void findBySeller_Id_Default_Success() {
+        //given
+        Seller seller = Seller.builder()
+                .cpEmail("lafudgestore@naver.com")
+                .cpPassword("password1234")
+                .phoneNumber("010-7797-8841") // 대표 전화번호
+                .epName("손준호") // 대표자명
+                .cpName("(주)슬로우스탠다드") // 상호명
+                .cpCode("178-86-01188") // 10자리의 사업자 등록번호
+                .cpAddress("경기도 의정부시 오목로225번길 94, 씨와이파크 (민락동)") // 사업장 소재지(회사주소)
+                .netProceeds(1000)
+                .build();
+
+        Brand brand = Brand.builder()
+                .name("라퍼지스토어")
+                .description("라퍼지스토어(LAFUDGESTORE)는 다양한 사람들이 일상에서 편안하게 사용할 수 있는 제품을 전개합니다. 새롭게 변화되는 소재와 실루엣, 일상에 자연스레 스며드는 제품을 제작하여 지속적인 실속형 소비의 가치를 실천합니다.")
+                .authorityStatus(AuthorityStatus.PENDING)
+                .likes(0)
+                .seller(seller)
+                .build();
+
+        sellerRepository.save(seller);
+        brandRepository.save(brand);
+
+        //when
+        Brand brandFound = brandRepository.findBySeller_Id(1L).get();
+
+        //then
+        assertNotNull(brandFound);
+        assertEquals(brand.getName(), brandFound.getName());
+
+    }
+
+}

--- a/src/test/java/org/boot/growup/source/seller/persist/repository/SellerRepositoryTest.java
+++ b/src/test/java/org/boot/growup/source/seller/persist/repository/SellerRepositoryTest.java
@@ -1,0 +1,54 @@
+package org.boot.growup.source.seller.persist.repository;
+
+import org.boot.growup.source.seller.persist.entity.Seller;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ExtendWith(SpringExtension.class)
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SellerRepositoryTest {
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    @Test
+    public void sellerInsert_success() {
+        //given
+        Seller seller = Seller.builder()
+                .cpEmail("lafudgestore@naver.com")
+                .cpPassword("password1234")
+                .phoneNumber("010-7797-8841") // 대표 전화번호
+                .epName("손준호") // 대표자명
+                .cpName("(주)슬로우스탠다드") // 상호명
+                .cpCode("178-86-01188") // 10자리의 사업자 등록번호
+                .cpAddress("경기도 의정부시 오목로225번길 94, 씨와이파크 (민락동)") // 사업장 소재지(회사주소)
+                .netProceeds(1000)
+                .build();
+
+        //when
+        Seller sellerDB = sellerRepository.save(seller);
+
+        //then
+        assertNotNull(sellerDB);
+        assertEquals(seller.getCpEmail(), sellerDB.getCpEmail());
+        assertEquals(seller.getCpPassword(), sellerDB.getCpPassword());
+        assertEquals(seller.getPhoneNumber(), sellerDB.getPhoneNumber());
+        assertEquals(seller.getEpName(), sellerDB.getEpName());
+        assertEquals(seller.getCpName(), sellerDB.getCpName());
+        assertEquals(seller.getCpCode(), sellerDB.getCpCode());
+        assertEquals(seller.getCpAddress(), sellerDB.getCpAddress());
+        assertEquals(seller.getNetProceeds(), sellerDB.getNetProceeds());
+        assertEquals(1L, sellerDB.getId());
+    }
+
+
+}

--- a/src/test/java/org/boot/growup/source/seller/service/BrandImageServiceImplTest.java
+++ b/src/test/java/org/boot/growup/source/seller/service/BrandImageServiceImplTest.java
@@ -1,0 +1,94 @@
+package org.boot.growup.source.seller.service;
+
+import org.boot.growup.common.ImageStore;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.BrandImage;
+import org.boot.growup.source.seller.persist.repository.BrandImageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.File;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BrandImageServiceImplTest {
+    @InjectMocks
+    private BrandImageServiceImpl brandImageServiceImpl;
+
+    @Mock
+    private BrandImageRepository brandImageRepository;
+
+    @Mock
+    private ImageStore imageStore;
+
+    @BeforeEach
+    public void setUp() {
+        File dir = new File("/Users/gnues/Documents/grow/Images/brandImages/");
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+    }
+
+    @Test
+    public void saveBrandImages_Default_Success() {
+        // given
+        Brand brand = new Brand();
+
+        // 두 개의 MockMultipartFile 객체 생성
+        MockMultipartFile file1 = new MockMultipartFile("file", "test1.jpg", "image/jpeg", "test image content 1".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile("file", "test2.jpg", "image/jpeg", "test image content 2".getBytes());
+
+        // Mock된 메소드 동작 설정
+        when(imageStore.createStoreFileName("test1.jpg")).thenReturn("uud-test1.jpg");
+        when(imageStore.createStoreFileName("test2.jpg")).thenReturn("uud-test2.jpg");
+
+        // when
+        brandImageServiceImpl.saveBrandImages(List.of(file1, file2), brand);
+
+        // then
+        verify(imageStore, times(1)).createStoreFileName("test1.jpg");
+        verify(imageStore, times(1)).createStoreFileName("test2.jpg");
+
+        verify(brandImageRepository, times(2)).save(any(BrandImage.class));
+    }
+
+    @Test
+    public void readBrandImages_Default_Success() {
+
+    }
+
+    @Test
+    public void updateBrandImages_Default_Success() {
+        // given
+        Brand brand = Brand.builder().id(1L).build();
+
+        // 두 개의 MockMultipartFile 객체 생성
+        MockMultipartFile file1 = new MockMultipartFile("file", "test1.jpg", "image/jpeg", "test image content 1".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile("file", "test2.jpg", "image/jpeg", "test image content 2".getBytes());
+
+        // Mock된 메소드 동작 설정
+        when(imageStore.createStoreFileName("test1.jpg")).thenReturn("uud-test1.jpg");
+        when(imageStore.createStoreFileName("test2.jpg")).thenReturn("uud-test2.jpg");
+
+        // when
+        brandImageServiceImpl.updateBrandImages(List.of(file1, file2), brand);
+
+        // then
+        verify(imageStore, times(1)).createStoreFileName("test1.jpg");
+        verify(imageStore, times(1)).createStoreFileName("test2.jpg");
+
+        verify(brandImageRepository, times(2)).save(any(BrandImage.class));
+    }
+
+}

--- a/src/test/java/org/boot/growup/source/seller/service/BrandServiceImplTest.java
+++ b/src/test/java/org/boot/growup/source/seller/service/BrandServiceImplTest.java
@@ -2,7 +2,7 @@ package org.boot.growup.source.seller.service;
 
 import org.boot.growup.common.constant.BaseException;
 import org.boot.growup.common.error.ErrorCode;
-import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.common.enumerate.AuthorityStatus;
 import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
 import org.boot.growup.source.seller.persist.entity.Brand;
 import org.boot.growup.source.seller.persist.entity.Seller;

--- a/src/test/java/org/boot/growup/source/seller/service/BrandServiceImplTest.java
+++ b/src/test/java/org/boot/growup/source/seller/service/BrandServiceImplTest.java
@@ -1,0 +1,159 @@
+package org.boot.growup.source.seller.service;
+
+import org.boot.growup.common.constant.BaseException;
+import org.boot.growup.common.error.ErrorCode;
+import org.boot.growup.source.seller.constant.AuthorityStatus;
+import org.boot.growup.source.seller.dto.request.RegisterBrandRequestDTO;
+import org.boot.growup.source.seller.persist.entity.Brand;
+import org.boot.growup.source.seller.persist.entity.Seller;
+import org.boot.growup.source.seller.persist.repository.BrandRepository;
+import org.boot.growup.source.seller.persist.repository.SellerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BrandServiceImplTest {
+
+    @Autowired
+    private BrandServiceImpl brandServiceImpl;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Autowired
+    private SellerRepository sellerRepository;
+
+    RegisterBrandRequestDTO registerBrandRequestDTO1;
+    RegisterBrandRequestDTO registerBrandRequestDTO2;
+    RegisterBrandRequestDTO registerBrandRequestDTO3;
+    Seller seller;
+    Seller seller2;
+
+    @BeforeEach
+    void setUp() {
+        sellerRepository.deleteAll();  // 기존 데이터 삭제
+        brandRepository.deleteAll();
+
+        registerBrandRequestDTO1 = RegisterBrandRequestDTO.builder()
+                .name("라퍼지스토어")
+                .description("라퍼지스토어(LAFUDGESTORE)는 다양한 사람들이 일상에서 편안하게 사용할 수 있는 제품을 전개합니다. 새롭게 변화되는 소재와 실루엣, 일상에 자연스레 스며드는 제품을 제작하여 지속적인 실속형 소비의 가치를 실천합니다.")
+                .build();
+        registerBrandRequestDTO2 = RegisterBrandRequestDTO.builder()
+                .name("드로우핏")
+                .description("드로우핏(DRAW FIT)은 핏과 착용감을 중요하게 여기며 컨템포러리&모던 룩을 지향하는 브랜드입니다. 뛰어난 퀄리티의 좋은 소재를 다양하게 구성해 바느질까지 세심하게 신경 써서 완성하고 고유의 핏과 무드를 머금은 웨어러블한 디자인의 아이템을 합리적인 가격으로 소개합니다.")
+                .build();
+        registerBrandRequestDTO3 = RegisterBrandRequestDTO.builder()
+                .name("라퍼지스토어")
+                .description("라퍼지스토어(LAFUDGESTORE)는 다양한 사람들이 일상에서 편안하게 사용할 수 있는 제품을 전개합니다. 새롭게 변화되는 소재와 실루엣, 일상에 자연스레 스며드는 제품을 제작하여 지속적인 실속형 소비의 가치를 실천합니다.")
+                .build();
+        seller = Seller.builder()
+                .cpEmail("lafudgestore@naver.com")
+                .cpPassword("password1234")
+                .phoneNumber("010-7797-8841") // 대표 전화번호
+                .epName("손준호") // 대표자명
+                .cpName("(주)슬로우스탠다드") // 상호명
+                .cpCode("178-86-01188") // 10자리의 사업자 등록번호
+                .cpAddress("경기도 의정부시 오목로225번길 94, 씨와이파크 (민락동)") // 사업장 소재지(회사주소)
+                .netProceeds(1000)
+                .build();
+        seller2 = Seller.builder()
+                .cpEmail("drawfit@naver.com")
+                .cpPassword("password1234")
+                .phoneNumber("02-3394-8271") // 대표 전화번호
+                .epName("조현민") // 대표자명
+                .cpName("디알에프티 주식회사") // 상호명
+                .cpCode("722-87-00697") // 10자리의 사업자 등록번호
+                .cpAddress("서울특별시 성동구 자동차시장1길 81, FCN빌딩 5층 (용답동)") // 사업장 소재지(회사주소)
+                .netProceeds(1000)
+                .build();
+    }
+
+    @Test
+    void registerBrand_Default_Success() {
+        //given
+        sellerRepository.save(seller);
+
+        //when
+        brandServiceImpl.registerBrand(registerBrandRequestDTO1, seller);
+        Brand brand = brandRepository.findById(seller.getId()).get();
+
+        //then
+        assertNotNull(brand);
+        assertEquals(registerBrandRequestDTO1.getName(), brand.getName());
+        assertEquals(registerBrandRequestDTO1.getDescription(), brand.getDescription());
+    }
+
+    @Test
+    void registerBrand_DuplicateName_ThrowsIllegalStateException() {
+        //given
+        sellerRepository.save(seller);
+        sellerRepository.save(seller2);
+        brandServiceImpl.registerBrand(registerBrandRequestDTO1, seller);
+
+        //when
+        BaseException e = assertThrows(BaseException.class, () -> brandServiceImpl.registerBrand(registerBrandRequestDTO3, seller2));
+
+        //then
+        assertEquals(e.getErrorCode(), ErrorCode.BRAND_NAME_ALREADY_EXISTS);
+    }
+
+    @Test
+    public void readBrandBySellerId_Default_Success() {
+        //given
+        Brand brand = Brand.builder()
+                .name("라퍼지스토어")
+                .description("라퍼지스토어(LAFUDGESTORE)는 다양한 사람들이 일상에서 편안하게 사용할 수 있는 제품을 전개합니다. 새롭게 변화되는 소재와 실루엣, 일상에 자연스레 스며드는 제품을 제작하여 지속적인 실속형 소비의 가치를 실천합니다.")
+                .authorityStatus(AuthorityStatus.PENDING)
+                .likes(0)
+                .seller(seller)
+                .build();
+
+        sellerRepository.save(seller);
+        brandRepository.save(brand);
+
+        //when
+        Brand brandFound = brandServiceImpl.readBrandBySellerId(seller.getId());
+
+        //then
+        assertNotNull(brandFound);
+        assertEquals(brand.getName(), brandFound.getName());
+
+    }
+
+    @Test
+    public void readBrandBySellerId_SellerHasNotBrand_ThrowBaseException() {
+        //given
+        //when
+        BaseException e = assertThrows(BaseException.class, () -> brandServiceImpl.readBrandBySellerId(2L));
+
+        //then
+        assertEquals(e.getErrorCode(), ErrorCode.BRAND_BY_SELLER_NOT_FOUND);
+    }
+
+    @Test
+    public void updateBrand_Default_Success() {
+        //given
+        sellerRepository.save(seller);
+        brandServiceImpl.registerBrand(registerBrandRequestDTO1, seller);
+
+        //when
+        brandServiceImpl.updateBrand(registerBrandRequestDTO3, seller);
+        Brand brand = brandRepository.findBySeller_Id(1L).get();
+
+        //then
+        assertNotNull(brand);
+        assertEquals(registerBrandRequestDTO3.getName(), brand.getName());
+        assertEquals(registerBrandRequestDTO3.getDescription(), brand.getDescription());
+
+    }
+}


### PR DESCRIPTION
## 변경사항
### AS-IS
- 판매자 브랜드 등록 기능
- 판매자 브랜드 수정 기능
- 판매자 브랜드 조회 기능
- 원래 로직은 제공받은 토큰에 의해 현재 판매자의 정보를 확인하고 해당 판매자의 정보를 통해 브랜드 등록, 수정, 조회를 진행합니다만,
현재는 일괄적으로 id 1번을 가진 seller를 기준으로 진행합니다.


### TO-BE
- 추후 유저 API와 통합 진행 및 테스트 진행해야함.
- Product와 Brand 엔티티끼리의 연관관계를 결정해야 함.
- 이미지 저장 방식에 대해 현재는 S3가 아닌 로컬에 저장함.
- 브랜드 도메인에 해당하는 모든 API를 일괄적으로 제가 개발하는 게 좋을 것 같음.

## 테스트
- [x] 테스트 코드 : 단, Controller 테스트는 작성하지 않음.
- [x] API 테스트