### PR TITLE
Feature/order/order  결제완료 후 배송, 구매확정까지 단계별 구현

### DIFF
--- a/src/main/java/org/boot/growup/auth/persist/entity/Seller.java
+++ b/src/main/java/org/boot/growup/auth/persist/entity/Seller.java
@@ -77,7 +77,7 @@ public class Seller extends BaseEntity {
 
     /* 총 누적 정산금 증액 */
     public void increaseNetProceeds(int netProceed) {
-        this.netProceeds+=netProceed;
+        this.netProceeds += netProceed;
     }
 
 }

--- a/src/main/java/org/boot/growup/auth/persist/entity/Seller.java
+++ b/src/main/java/org/boot/growup/auth/persist/entity/Seller.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.boot.growup.auth.model.UserModel;
-import org.boot.growup.common.constant.Provider;
 import org.boot.growup.common.constant.Role;
 import org.boot.growup.auth.model.dto.request.SellerSignUpRequestDTO;
 import org.boot.growup.common.entity.BaseEntity;
@@ -71,8 +70,14 @@ public class Seller extends BaseEntity {
                 .cpCode(request.getCpCode())
                 .cpName(request.getCpName())
                 .cpAddress(request.getCpAddress())
+                .netProceeds(0)
                 .role(Role.SELLER)
                 .build();
+    }
+
+    /* 총 누적 정산금 증액 */
+    public void increaseNetProceeds(int netProceed) {
+        this.netProceeds+=netProceed;
     }
 
 }

--- a/src/main/java/org/boot/growup/common/constant/Commission.java
+++ b/src/main/java/org/boot/growup/common/constant/Commission.java
@@ -4,15 +4,15 @@ import java.math.BigDecimal;
 
 public class Commission {
     public static final BigDecimal COMMISSION_RATE = new BigDecimal("0.094"); // 쇼핑몰 수수료 비율 9.4%
-    private Commission(){}
+    private Commission() {}
 
     /* 쇼핑몰 수수료 연산 */
-    public static int calculateCommission(int orderItemPrice){
+    public static int calculateCommission(int orderItemPrice) {
         return COMMISSION_RATE.multiply(new BigDecimal(orderItemPrice)).intValue();
     }
 
     /* 판매자 예상 정산금 연산 */
-    public static int calculateNetProceed(int orderItemPrice){
+    public static int calculateNetProceed(int orderItemPrice) {
         return orderItemPrice - COMMISSION_RATE.multiply(new BigDecimal(orderItemPrice)).intValue();
     }
 }

--- a/src/main/java/org/boot/growup/common/constant/Commission.java
+++ b/src/main/java/org/boot/growup/common/constant/Commission.java
@@ -1,0 +1,18 @@
+package org.boot.growup.common.constant;
+
+import java.math.BigDecimal;
+
+public class Commission {
+    public static final BigDecimal COMMISSION_RATE = new BigDecimal("0.094"); // 쇼핑몰 수수료 비율 9.4%
+    private Commission(){}
+
+    /* 쇼핑몰 수수료 연산 */
+    public static int calculateCommission(int orderItemPrice){
+        return COMMISSION_RATE.multiply(new BigDecimal(orderItemPrice)).intValue();
+    }
+
+    /* 판매자 예상 정산금 연산 */
+    public static int calculateNetProceed(int orderItemPrice){
+        return orderItemPrice - COMMISSION_RATE.multiply(new BigDecimal(orderItemPrice)).intValue();
+    }
+}

--- a/src/main/java/org/boot/growup/common/constant/ErrorCode.java
+++ b/src/main/java/org/boot/growup/common/constant/ErrorCode.java
@@ -86,8 +86,14 @@ public enum ErrorCode {
 
     /* Order 관련 */
     ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, 404, false, "해당 주문을 찾을 수 없습니다."),
+    ORDER_ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, 404, false, "해당 주문항목을 찾을 수 없습니다."),
     PAY_NOT_SUCCESS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문의 결제 사실을 확인할 수 없습니다."),
     PAY_ALREADY_SUCCESS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문의 결제는 성공했습니다."),
+    ORDER_ITEM_NOT_PAID_STATUS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문 항목은 PAID 상태가 아닙니다."),
+    ORDER_ITEM_NOT_PAID_OR_PRE_SHIPPED_STATUS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문 항목은 PAID 상태 혹은 PRE_SHIPPED 상태가 아닙니다."),
+    ORDER_ITEM_NOT_SHIPPED_STATUS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문 항목은 SHIPPED 상태가 아닙니다."),
+    ORDER_ITEM_NOT_PENDING_SHIPMENT_STATUS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문 항목은 PENDING_SHIPMENT 상태가 아닙니다."),
+    ORDER_ITEM_NOT_IN_TRANSIT_STATUS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문 항목은 IN_TRANSIT 상태가 아닙니다."),
 
     /* Growpay 관련 */
     GROWPAY_NOT_FOUND(HttpStatus.BAD_REQUEST, 404, false, "해당 Growpay 계좌를 찾을 수 없습니다."),

--- a/src/main/java/org/boot/growup/common/constant/OrderStatus.java
+++ b/src/main/java/org/boot/growup/common/constant/OrderStatus.java
@@ -2,8 +2,8 @@ package org.boot.growup.common.constant;
 
 public enum OrderStatus {
     /* 결제 관련 */
-    PRE_PAYED, // 주문 번호 생성된 상태
-    PAYED, // Order 객체 생성 및 결제 완료된 상태
+    PRE_PAID, // 주문 번호 생성된 상태
+    PAID, // Order 객체 생성 및 결제 완료된 상태
     REJECTED, // PG사 결제 거부 상태 (결제 실패)
     CANCELED, // 결제 도중 구매자가 결제 중단 혹은 해당 주문을 취소한 상태
 

--- a/src/main/java/org/boot/growup/common/utils/DataLoader.java
+++ b/src/main/java/org/boot/growup/common/utils/DataLoader.java
@@ -84,7 +84,6 @@ public class DataLoader {
         paidOrderItem1.ordered(order1);
         paidOrderItem1.payed();
 
-
         OrderItem preshippedOrderItem1 = OrderItem.builder()
                 .deliveryFee(p2.getDeliveryFee()) // 1000원
                 .productOptionPrice(p2_po1.getOptionPrice()) // 50원

--- a/src/main/java/org/boot/growup/common/utils/DataLoader.java
+++ b/src/main/java/org/boot/growup/common/utils/DataLoader.java
@@ -594,7 +594,6 @@ public class DataLoader {
                 product5, product6, product7, product8
         ));
     }
-
     public void adminInit(){
         Admin admin = Admin.builder()
                 .email("root@growteam.com")

--- a/src/main/java/org/boot/growup/common/utils/DataLoader.java
+++ b/src/main/java/org/boot/growup/common/utils/DataLoader.java
@@ -4,19 +4,16 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.boot.growup.auth.persist.repository.SellerRepository;
 import org.boot.growup.auth.persist.entity.Seller;
-import org.boot.growup.common.constant.AuthorityStatus;
-import org.boot.growup.common.constant.Gender;
-import org.boot.growup.common.constant.Provider;
-import org.boot.growup.common.constant.Role;
+import org.boot.growup.common.constant.*;
 import org.boot.growup.auth.persist.entity.Admin;
 import org.boot.growup.auth.persist.repository.AdminRepository;
 import org.boot.growup.auth.persist.entity.Customer;
 import org.boot.growup.auth.persist.repository.CustomerRepository;
+import org.boot.growup.order.persist.entity.Order;
+import org.boot.growup.order.persist.entity.OrderItem;
+import org.boot.growup.order.persist.repository.OrderRepository;
 import org.boot.growup.product.persist.entity.*;
-import org.boot.growup.product.persist.repository.BrandRepository;
-import org.boot.growup.product.persist.repository.MainCategoryRepository;
-import org.boot.growup.product.persist.repository.ProductRepository;
-import org.boot.growup.product.persist.repository.SubCategoryRepository;
+import org.boot.growup.product.persist.repository.*;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -35,6 +32,8 @@ public class DataLoader {
     private final PasswordEncoder passwordEncoder;
     private final CustomerRepository customerRepository;
     private final AdminRepository adminRepository;
+    private final ProductOptionRepository productOptionRepository;
+    private final OrderRepository orderRepository;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
@@ -44,7 +43,66 @@ public class DataLoader {
         brandInit();
         categoryInit();
         productInit();
+        orderInit();
         adminInit();
+    }
+
+    private void orderInit() {
+        Customer customer1 = customerRepository.findById(1L).get();
+        Seller seller1 = sellerRepository.findById(1L).get();
+        Seller seller2 = sellerRepository.findById(2L).get();
+
+        Product p1 = productRepository.findById(1L).get();
+        ProductOption p1_po1 = productOptionRepository.findById(1L).get();
+
+        Product p2 = productRepository.findById(2L).get();
+        ProductOption p2_po1 = productOptionRepository.findById(3L).get();
+
+        Order order1 = Order.builder()
+                .customer(customer1)
+                .payMethod(PayMethod.CARD)
+                .receiverPostCode("12345")
+                .receiverAddress("서울시 용산")
+                .receiverName("정태승")
+                .receiverPhone("010-1234-5678")
+                .merchantUid("20240909123456")
+                .message("문앞에둬주세요.")
+                .build();
+
+        OrderItem paidOrderItem1 = OrderItem.builder()
+                .deliveryFee(p1.getDeliveryFee()) // 1000원
+                .productOptionPrice(p1_po1.getOptionPrice()) // 100원
+                .orderStatus(OrderStatus.PRE_PAID)
+                .productOption(p1_po1)
+                .productName(p1.getName()) // 맨투맨 A
+                .product(p1)
+                .count(1)
+                .productOptionName(p1_po1.getOptionName()) // 블랙 / XL
+                .seller(seller1)
+                .build();
+
+        paidOrderItem1.ordered(order1);
+        paidOrderItem1.payed();
+
+
+        OrderItem preshippedOrderItem1 = OrderItem.builder()
+                .deliveryFee(p2.getDeliveryFee()) // 1000원
+                .productOptionPrice(p2_po1.getOptionPrice()) // 50원
+                .productOption(p2_po1)
+                .orderStatus(OrderStatus.PRE_PAID)
+                .product(p2)
+                .count(1)
+                .productName(p2.getName()) // 반팔 티셔츠 B
+                .productOptionName(p2_po1.getOptionName()) // 화이트 / M
+                .order(order1)
+                .seller(seller2)
+                .build();
+
+        preshippedOrderItem1.ordered(order1);
+        preshippedOrderItem1.payed();
+        preshippedOrderItem1.preShipped();
+
+        orderRepository.save(order1);
     }
 
     public void customerInit(){
@@ -212,7 +270,7 @@ public class DataLoader {
                 .cpCode("178-86-01188") // 10자리의 사업자 등록번호
                 .cpAddress("경기도 의정부시 오목로225번길 94, 씨와이파크 (민락동)") // 사업장 소재지(회사주소)
                 .role(Role.SELLER)
-                .netProceeds(1000)
+                .netProceeds(0)
                 .build();
         sellerRepository.save(seller);
 
@@ -225,7 +283,7 @@ public class DataLoader {
                 .cpCode("722-87-00697") // 10자리의 사업자 등록번호
                 .cpAddress("서울특별시 성동구 자동차시장1길 81, FCN빌딩 5층 (용답동)") // 사업장 소재지(회사주소)
                 .role(Role.SELLER)
-                .netProceeds(1000)
+                .netProceeds(0)
                 .build();
 
         sellerRepository.save(seller2);

--- a/src/main/java/org/boot/growup/order/application/OrderApplication.java
+++ b/src/main/java/org/boot/growup/order/application/OrderApplication.java
@@ -3,13 +3,17 @@ package org.boot.growup.order.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.boot.growup.auth.persist.entity.Customer;
+import org.boot.growup.auth.persist.entity.Seller;
 import org.boot.growup.auth.service.CustomerService;
+import org.boot.growup.auth.service.SellerService;
 import org.boot.growup.common.constant.ErrorCode;
 import org.boot.growup.common.model.BaseException;
-import org.boot.growup.order.controller.PortOneFeignClient;
+import org.boot.growup.order.client.PortOneFeignClient;
 import org.boot.growup.order.dto.OrderDTO;
 import org.boot.growup.order.dto.OrderItemDTO;
+import org.boot.growup.order.dto.request.PatchShipmentRequestDTO;
 import org.boot.growup.order.dto.request.ProcessNormalOrderRequestDTO;
+import org.boot.growup.order.dto.response.GetOrderResponseDTO;
 import org.boot.growup.order.persist.entity.Order;
 import org.boot.growup.order.service.OrderService;
 import org.boot.growup.product.persist.entity.ProductOption;
@@ -27,6 +31,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class OrderApplication {
     private final CustomerService customerService;
+    private final SellerService sellerService;
     private final ProductService productService;
     private final OrderService orderService;
     private final PortOneFeignClient portOneFeignClient;
@@ -79,5 +84,50 @@ public class OrderApplication {
 
         // rejected 상태로 변경
         orderService.rejectNormalOrder(merchantUid, customer);
+    }
+
+    public void patchPreShipped(Long orderItemId) {
+        Seller seller = sellerService.getCurrentSeller();
+
+        orderService.preshippedOrder(orderItemId, seller);
+    }
+
+
+    public void patchShipped(Long orderItemId) {
+        Seller seller = sellerService.getCurrentSeller();
+
+        orderService.shippedOrder(orderItemId, seller);
+    }
+
+    public void patchShipment(Long orderItemId, PatchShipmentRequestDTO patchShipmentRequestDTO) {
+        Seller seller = sellerService.getCurrentSeller();
+
+        orderService.shipmentOrder(orderItemId, seller, patchShipmentRequestDTO);
+    }
+
+    public void patchTransit(Long orderItemId) {
+        Seller seller = sellerService.getCurrentSeller();
+
+        orderService.transitOrder(orderItemId, seller);
+    }
+
+    public void patchArrived(Long orderItemId) {
+        Seller seller = sellerService.getCurrentSeller();
+
+        orderService.arrivedOrder(orderItemId, seller);
+    }
+
+    public void patchPurchaseConfirmed(String merchantUid, Long orderItemId) {
+        Customer customer = customerService.getCurrentCustomer();
+
+        orderService.confirmedPurchaseOrder(merchantUid, orderItemId, customer);
+    }
+
+    public GetOrderResponseDTO getOrder(String merchantUid) {
+        Customer customer = customerService.getCurrentCustomer();
+
+        Order order = orderService.getOrder(merchantUid, customer);
+
+        return GetOrderResponseDTO.from(order);
     }
 }

--- a/src/main/java/org/boot/growup/order/client/PortOneFeignClient.java
+++ b/src/main/java/org/boot/growup/order/client/PortOneFeignClient.java
@@ -1,4 +1,4 @@
-package org.boot.growup.order.controller;
+package org.boot.growup.order.client;
 
 import org.boot.growup.order.dto.PortOnePaymentDTO;
 import org.springframework.cloud.openfeign.FeignClient;

--- a/src/main/java/org/boot/growup/order/controller/CustomerOrderController.java
+++ b/src/main/java/org/boot/growup/order/controller/CustomerOrderController.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.boot.growup.common.model.BaseResponse;
 import org.boot.growup.order.application.OrderApplication;
 import org.boot.growup.order.dto.request.ProcessNormalOrderRequestDTO;
+import org.boot.growup.order.dto.response.GetOrderResponseDTO;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -50,4 +51,35 @@ public class CustomerOrderController {
         orderApplication.rejectNormalOrder(merchantUid);
     }
 
+    /**
+     * [PATCH]
+     * 구매자가 해당 orderItem을 구매 확정 상태로 변경함.
+     * @header CustomerAccesstoken
+     * @param merchantUid 주문 번호
+     * @param orderItemId 주문 항목ID
+     */
+    @PatchMapping("/purchase-confirmed/{merchantUid}/{orderItemId}")
+    public void patchPurchaseConfirmed(
+            @PathVariable String merchantUid,
+            @PathVariable Long orderItemId
+    ){
+        orderApplication.patchPurchaseConfirmed(merchantUid, orderItemId);
+    }
+
+    /**
+     * [GET]
+     * 구매자의 주문 내역 단일 조회
+     * @header CustomerAccesstoken
+     * @param merchantUid 주문 번호
+     */
+    @GetMapping("/{merchantUid}")
+    public BaseResponse<GetOrderResponseDTO> getOrder(@PathVariable String merchantUid){
+        return new BaseResponse<>(orderApplication.getOrder(merchantUid));
+    }
+
+    // 환불 요청
+
+    // 배송 조회
+
+    // 그로우페이 결제
 }

--- a/src/main/java/org/boot/growup/order/controller/SellerOrderController.java
+++ b/src/main/java/org/boot/growup/order/controller/SellerOrderController.java
@@ -1,0 +1,71 @@
+package org.boot.growup.order.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.boot.growup.order.application.OrderApplication;
+import org.boot.growup.order.dto.request.PatchShipmentRequestDTO;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/sellers/orders")
+@RequiredArgsConstructor
+public class SellerOrderController {
+    private final OrderApplication orderApplication;
+
+    /**
+     * [PATCH]
+     * 주문항목 PAID -> PRE-SHIPPED로 상태 변경
+     * @header SellerAccesstoken
+     * @param orderItemId 주문항목ID
+     */
+    @PatchMapping("/preshipped/{orderItemId}")
+    public void patchPreShipped(@PathVariable Long orderItemId) {
+        orderApplication.patchPreShipped(orderItemId);
+    }
+
+    /**
+     * [PATCH]
+     * 주문항목 PAID, PRE-SHIPPED -> SHIPPED로 상태 변경
+     * @header SellerAccesstoken
+     * @param orderItemId 주문항목ID
+     */
+    @PatchMapping("/shipped/{orderItemId}")
+    public void patchShipped(@PathVariable Long orderItemId) {
+        orderApplication.patchShipped(orderItemId);
+    }
+
+    /**
+     * [PATCH]
+     * 주문항목 SHIPPED -> PENDING_SHIPMENT로 상태 변경
+     * @header SellerAccesstoken
+     * @body PatchShipmentRequestDTO 운송자번호 및 택배사 정보
+     * @param orderItemId 주문항목ID
+     */
+    @PatchMapping("/shipment/{orderItemId}")
+    public void patchShipment(@PathVariable Long orderItemId, @Valid @RequestBody PatchShipmentRequestDTO patchShipmentRequestDTO) {
+        orderApplication.patchShipment(orderItemId, patchShipmentRequestDTO);
+    }
+
+    /**
+     * [PATCH]
+     * 주문항목 PENDING_SHIPMENT -> IN_TRANSIT로 상태 변경
+     * @header SellerAccesstoken
+     * @param orderItemId 주문항목ID
+     */
+    @PatchMapping("/transit/{orderItemId}")
+    public void patchTransit(@PathVariable Long orderItemId) {
+        orderApplication.patchTransit(orderItemId);
+    }
+
+    /**
+     * [PATCH]
+     * 주문항목 IN_TRANSIT -> ARRIVED로 상태 변경
+     * @header SellerAccesstoken
+     * @param orderItemId 주문항목ID
+     */
+    @PatchMapping("/arrived/{orderItemId}")
+    public void patchArrived(@PathVariable Long orderItemId) {
+        orderApplication.patchArrived(orderItemId);
+    }
+
+}

--- a/src/main/java/org/boot/growup/order/dto/request/PatchShipmentRequestDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/request/PatchShipmentRequestDTO.java
@@ -1,0 +1,16 @@
+package org.boot.growup.order.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PatchShipmentRequestDTO {
+    @NotBlank(message = "운송장 번호를 입력해야합니다.")
+    private String trackingNumber;
+
+    @NotNull(message = "택배사 코드를 입력해야합니다.")
+    private int carrierCode;
+}

--- a/src/main/java/org/boot/growup/order/dto/response/GetOrderItemResponseDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/response/GetOrderItemResponseDTO.java
@@ -16,7 +16,6 @@ public class GetOrderItemResponseDTO {
     private String productOptionName;
     private int productOptionPrice;
 
-
     public static GetOrderItemResponseDTO from(OrderItem orderItem) {
         return GetOrderItemResponseDTO.builder()
                 .id(orderItem.getId())

--- a/src/main/java/org/boot/growup/order/dto/response/GetOrderItemResponseDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/response/GetOrderItemResponseDTO.java
@@ -1,0 +1,31 @@
+package org.boot.growup.order.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import org.boot.growup.common.constant.OrderStatus;
+import org.boot.growup.order.persist.entity.OrderItem;
+
+@Data
+@Builder
+public class GetOrderItemResponseDTO {
+    private Long id;
+    private int count;
+    private OrderStatus orderStatus;
+    private int deliveryFee;
+    private String productName;
+    private String productOptionName;
+    private int productOptionPrice;
+
+
+    public static GetOrderItemResponseDTO from(OrderItem orderItem) {
+        return GetOrderItemResponseDTO.builder()
+                .id(orderItem.getId())
+                .count(orderItem.getCount())
+                .orderStatus(orderItem.getOrderStatus())
+                .deliveryFee(orderItem.getDeliveryFee())
+                .productName(orderItem.getProductName())
+                .productOptionName(orderItem.getProductOptionName())
+                .productOptionPrice(orderItem.getProductOptionPrice())
+                .build();
+    }
+}

--- a/src/main/java/org/boot/growup/order/dto/response/GetOrderResponseDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/response/GetOrderResponseDTO.java
@@ -1,0 +1,37 @@
+package org.boot.growup.order.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import org.boot.growup.common.constant.PayMethod;
+import org.boot.growup.order.persist.entity.Order;
+
+import java.util.List;
+
+@Data
+@Builder
+public class GetOrderResponseDTO {
+    private String merchantUid;
+    private int totalPrice;
+    private PayMethod payMethod;
+    private String message;
+    private String receiverName;
+    private String receiverPhone;
+    private String receiverPostCode;
+    private List<GetOrderItemResponseDTO> orderItems;
+
+    public static GetOrderResponseDTO from(Order order) {
+        return GetOrderResponseDTO.builder()
+                .merchantUid(order.getMerchantUid())
+                .totalPrice(order.getTotalPrice())
+                .payMethod(order.getPayMethod())
+                .message(order.getMessage())
+                .receiverName(order.getReceiverName())
+                .receiverPhone(order.getReceiverPhone())
+                .receiverPostCode(order.getReceiverPostCode())
+                .orderItems(order.getOrderItems().stream()
+                        .map(GetOrderItemResponseDTO::from)
+                        .toList()
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/boot/growup/order/persist/entity/Delivery.java
+++ b/src/main/java/org/boot/growup/order/persist/entity/Delivery.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.boot.growup.common.entity.BaseEntity;
+import org.boot.growup.order.dto.request.PatchShipmentRequestDTO;
 import org.hibernate.envers.AuditOverride;
 
 @Entity
@@ -27,7 +28,14 @@ public class Delivery extends BaseEntity{
     @Column(nullable = false)
     private int carrierCode;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_item_id")
+    @OneToOne(mappedBy = "delivery", fetch = FetchType.LAZY)
     private OrderItem orderItem;
+
+    public static Delivery of(PatchShipmentRequestDTO patchShipmentRequestDTO, OrderItem orderItem) {
+        return Delivery.builder()
+                .trackingNumber(patchShipmentRequestDTO.getTrackingNumber())
+                .carrierCode(patchShipmentRequestDTO.getCarrierCode())
+                .orderItem(orderItem)
+                .build();
+    }
 }

--- a/src/main/java/org/boot/growup/order/persist/entity/OrderItem.java
+++ b/src/main/java/org/boot/growup/order/persist/entity/OrderItem.java
@@ -171,7 +171,6 @@ public class OrderItem {
         return (this.deliveryFee + (this.productOptionPrice * this.count));
     }
 
-
     public void confirmedPurchase() {
         // ARRIVED -> PURCHASE_CONFIRM
         if(this.orderStatus == OrderStatus.ARRIVED){

--- a/src/main/java/org/boot/growup/order/persist/entity/OrderItem.java
+++ b/src/main/java/org/boot/growup/order/persist/entity/OrderItem.java
@@ -104,7 +104,7 @@ public class OrderItem {
         this.orderStatus = OrderStatus.PRE_PAID;
     }
 
-    public void payed(){
+    public void payed() {
         if(this.orderStatus != OrderStatus.PRE_PAID){
             throw new BaseException(ErrorCode.PAY_ALREADY_SUCCESS);
         }
@@ -113,14 +113,14 @@ public class OrderItem {
         this.orderStatus = OrderStatus.PAID;
     }
 
-    public void rejected(){
+    public void rejected() {
         if(this.orderStatus != OrderStatus.PRE_PAID){
             throw new BaseException(ErrorCode.PAY_ALREADY_SUCCESS);
         }
         this.orderStatus = OrderStatus.REJECTED;
     }
 
-    public void preShipped(){
+    public void preShipped() {
         // PAID -> PRE-SHIPPED
         if(this.orderStatus == OrderStatus.PAID){
             this.orderStatus = OrderStatus.PRE_SHIPPED;
@@ -131,7 +131,7 @@ public class OrderItem {
 
     public void shipped() {
         // PRE_SHIPPED, PAID -> SHIPPED
-        if(this.orderStatus == OrderStatus.PAID || this.orderStatus == OrderStatus.PRE_SHIPPED){
+        if(this.orderStatus == OrderStatus.PAID || this.orderStatus == OrderStatus.PRE_SHIPPED) {
             this.orderStatus = OrderStatus.SHIPPED;
             this.shipped_at = LocalDateTime.now();
             return;
@@ -141,7 +141,7 @@ public class OrderItem {
 
     public void shipment(Delivery delivery) {
         // SHIPPED -> PENDING_SHIPMENT
-        if(this.orderStatus == OrderStatus.SHIPPED){
+        if(this.orderStatus == OrderStatus.SHIPPED) {
             this.orderStatus = OrderStatus.PENDING_SHIPMENT;
             this.delivery = delivery;
             return;
@@ -151,7 +151,7 @@ public class OrderItem {
 
     public void transit() {
         // PENDING_SHIPMENT -> IN_TRANSIT
-        if(this.orderStatus == OrderStatus.PENDING_SHIPMENT){
+        if(this.orderStatus == OrderStatus.PENDING_SHIPMENT) {
             this.orderStatus = OrderStatus.IN_TRANSIT;
             return;
         }
@@ -160,20 +160,20 @@ public class OrderItem {
 
     public void arrived() {
         // IN_TRANSIT -> ARRIVED
-        if(this.orderStatus == OrderStatus.IN_TRANSIT){
+        if(this.orderStatus == OrderStatus.IN_TRANSIT) {
             this.orderStatus = OrderStatus.ARRIVED;
             return;
         }
         throw new BaseException(ErrorCode.ORDER_ITEM_NOT_IN_TRANSIT_STATUS);
     }
 
-    private int calculateOrderItemPrice(){
+    private int calculateOrderItemPrice() {
         return (this.deliveryFee + (this.productOptionPrice * this.count));
     }
 
     public void confirmedPurchase() {
         // ARRIVED -> PURCHASE_CONFIRM
-        if(this.orderStatus == OrderStatus.ARRIVED){
+        if(this.orderStatus == OrderStatus.ARRIVED) {
             this.orderStatus = OrderStatus.PURCHASE_CONFIRM;
             this.purchase_confirmed_at = LocalDateTime.now();
             this.seller.increaseNetProceeds(this.netProceed);

--- a/src/main/java/org/boot/growup/order/persist/entity/OrderItem.java
+++ b/src/main/java/org/boot/growup/order/persist/entity/OrderItem.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.boot.growup.auth.persist.entity.Seller;
+import org.boot.growup.common.constant.Commission;
 import org.boot.growup.common.constant.ErrorCode;
 import org.boot.growup.common.constant.OrderStatus;
 import org.boot.growup.common.model.BaseException;
@@ -64,15 +66,31 @@ public class OrderItem {
     @JoinColumn(name = "product_option_id")
     private ProductOption productOption;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_id")
+    private Seller seller;
+
+    @OneToOne(fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.ALL)
+    @JoinColumn(name = "delivery_id")
+    private Delivery delivery;
+
+    @Column(nullable = true)
+    private int netProceed;
+
+    @Column(nullable = true)
+    private int commission;
+
     public static OrderItem of(ProductOption option, Integer count) {
         return OrderItem.builder()
                 .productOption(option)
                 .productOptionName(option.getOptionName())
                 .deliveryFee(option.getProduct().getDeliveryFee())
+                .seller(option.getProduct().getSeller())
                 .product(option.getProduct())
                 .productName(option.getProduct().getName())
                 .productOptionPrice(option.getOptionPrice())
                 .count(count)
+                .seller(option.getProduct().getSeller())
                 .build();
     }
 
@@ -82,26 +100,86 @@ public class OrderItem {
         order.getOrderItems().add(this);
     }
 
-    public void prePayed(){
-        this.orderStatus = OrderStatus.PRE_PAYED;
+    public void prePaid(){
+        this.orderStatus = OrderStatus.PRE_PAID;
     }
 
     public void payed(){
-        if(this.orderStatus == OrderStatus.PRE_PAYED){
-            this.orderStatus = OrderStatus.PAYED;
+        if(this.orderStatus != OrderStatus.PRE_PAID){
+            throw new BaseException(ErrorCode.PAY_ALREADY_SUCCESS);
         }
-        throw new BaseException(ErrorCode.PAY_ALREADY_SUCCESS);
+        this.commission = Commission.calculateCommission(this.productOptionPrice) * this.count;
+        this.netProceed = Commission.calculateNetProceed(this.productOptionPrice) * this.count;
+        this.orderStatus = OrderStatus.PAID;
     }
 
     public void rejected(){
-        if(this.orderStatus == OrderStatus.PRE_PAYED){
-            this.orderStatus = OrderStatus.REJECTED;
+        if(this.orderStatus != OrderStatus.PRE_PAID){
+            throw new BaseException(ErrorCode.PAY_ALREADY_SUCCESS);
         }
-        throw new BaseException(ErrorCode.PAY_ALREADY_SUCCESS);
+        this.orderStatus = OrderStatus.REJECTED;
+    }
+
+    public void preShipped(){
+        // PAID -> PRE-SHIPPED
+        if(this.orderStatus == OrderStatus.PAID){
+            this.orderStatus = OrderStatus.PRE_SHIPPED;
+            return;
+        }
+        throw new BaseException(ErrorCode.ORDER_ITEM_NOT_PAID_STATUS);
+    }
+
+    public void shipped() {
+        // PRE_SHIPPED, PAID -> SHIPPED
+        if(this.orderStatus == OrderStatus.PAID || this.orderStatus == OrderStatus.PRE_SHIPPED){
+            this.orderStatus = OrderStatus.SHIPPED;
+            this.shipped_at = LocalDateTime.now();
+            return;
+        }
+        throw new BaseException(ErrorCode.ORDER_ITEM_NOT_PAID_OR_PRE_SHIPPED_STATUS);
+    }
+
+    public void shipment(Delivery delivery) {
+        // SHIPPED -> PENDING_SHIPMENT
+        if(this.orderStatus == OrderStatus.SHIPPED){
+            this.orderStatus = OrderStatus.PENDING_SHIPMENT;
+            this.delivery = delivery;
+            return;
+        }
+        throw new BaseException(ErrorCode.ORDER_ITEM_NOT_SHIPPED_STATUS);
+    }
+
+    public void transit() {
+        // PENDING_SHIPMENT -> IN_TRANSIT
+        if(this.orderStatus == OrderStatus.PENDING_SHIPMENT){
+            this.orderStatus = OrderStatus.IN_TRANSIT;
+            return;
+        }
+        throw new BaseException(ErrorCode.ORDER_ITEM_NOT_SHIPPED_STATUS);
+    }
+
+    public void arrived() {
+        // IN_TRANSIT -> ARRIVED
+        if(this.orderStatus == OrderStatus.IN_TRANSIT){
+            this.orderStatus = OrderStatus.ARRIVED;
+            return;
+        }
+        throw new BaseException(ErrorCode.ORDER_ITEM_NOT_IN_TRANSIT_STATUS);
     }
 
     private int calculateOrderItemPrice(){
-        log.info("deliveryFee = {}, productOptionPrice = {}, count = {}", deliveryFee, productOptionPrice, count);
         return (this.deliveryFee + (this.productOptionPrice * this.count));
+    }
+
+
+    public void confirmedPurchase() {
+        // ARRIVED -> PURCHASE_CONFIRM
+        if(this.orderStatus == OrderStatus.ARRIVED){
+            this.orderStatus = OrderStatus.PURCHASE_CONFIRM;
+            this.purchase_confirmed_at = LocalDateTime.now();
+            this.seller.increaseNetProceeds(this.netProceed);
+            return;
+        }
+        throw new BaseException(ErrorCode.ORDER_ITEM_NOT_IN_TRANSIT_STATUS);
     }
 }

--- a/src/main/java/org/boot/growup/order/persist/repository/OrderItemRepository.java
+++ b/src/main/java/org/boot/growup/order/persist/repository/OrderItemRepository.java
@@ -3,5 +3,9 @@ package org.boot.growup.order.persist.repository;
 import org.boot.growup.order.persist.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+    Optional<OrderItem> findByIdAndSellerId(Long id, Long sellerId);
+    Optional<OrderItem> findByIdAndOrderId(Long id, Long orderId);
 }

--- a/src/main/java/org/boot/growup/order/service/OrderService.java
+++ b/src/main/java/org/boot/growup/order/service/OrderService.java
@@ -1,7 +1,9 @@
 package org.boot.growup.order.service;
 
 import org.boot.growup.auth.persist.entity.Customer;
+import org.boot.growup.auth.persist.entity.Seller;
 import org.boot.growup.order.dto.OrderDTO;
+import org.boot.growup.order.dto.request.PatchShipmentRequestDTO;
 import org.boot.growup.order.persist.entity.Order;
 import org.boot.growup.product.persist.entity.ProductOption;
 
@@ -14,7 +16,7 @@ public interface OrderService {
     Order processNormalOrder(OrderDTO orderDTO, Map<ProductOption, Integer> productOptionCountMap, Customer customer);
 
     /*
-    주문번호 + 구매자 정보를 통해 Order를 찾고, OrderItem들을 PAYED 상태로 변경함.
+    주문번호 + 구매자 정보를 통해 Order를 찾고, OrderItem들을 PAYED 상태로 변경 및 수수료, 정산금을 계산함.
      */
     void completeOrder(String merchantUid, Customer customer);
 
@@ -22,4 +24,39 @@ public interface OrderService {
     주문번호 + 구매자 정보를 통해 Order를 찾고, OrderItem들을 REJECTED 상태로 변경함.
      */
     void rejectNormalOrder(String merchantUid, Customer customer);
+
+    /*
+    OrderItemId 및 Seller를 통해 OrderItem을 찾고, 해당 OrderItem을 PRE_SHIPPED 상태로 변경함.
+     */
+    void preshippedOrder(Long orderItemId, Seller seller);
+
+    /*
+    OrderItemId 및 Seller를 통해 OrderItem을 찾고, 해당 OrderItem을 SHIPPED 상태로 변경함.
+     */
+    void shippedOrder(Long orderItemId, Seller seller);
+
+    /*
+    OrderItemId 및 Seller를 통해 OrderItem을 찾고, 해당 OrderItem을 Delivery 등록 후 PENDING-SHIPMENT 상태로 변경함.
+     */
+    void shipmentOrder(Long orderItemId, Seller seller, PatchShipmentRequestDTO patchShipmentRequestDTO);
+
+    /*
+    OrderItemId 및 Seller를 통해 OrderItem을 찾고, 해당 OrderItem을 IN-TRANSIT 상태로 변경함.
+     */
+    void transitOrder(Long orderItemId, Seller seller);
+
+    /*
+    OrderItemId 및 Seller를 통해 OrderItem을 찾고, 해당 OrderItem을 ARRIVED 상태로 변경함.
+     */
+    void arrivedOrder(Long orderItemId, Seller seller);
+
+    /*
+    OrderItemId 및 Customer를 통해 OrderItem을 찾고 해당 OrderItem을 PURCHASE_CONFIRM 상태로 변경 및 판매자 총 정산금 증액
+     */
+    void confirmedPurchaseOrder(String merchantUid, Long orderItemId, Customer customer);
+
+    /*
+    merchantUid와 customer 정보로 Order를 가져옴.
+     */
+    Order getOrder(String merchantUid, Customer customer);
 }

--- a/src/main/java/org/boot/growup/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/org/boot/growup/order/service/impl/OrderServiceImpl.java
@@ -1,13 +1,18 @@
 package org.boot.growup.order.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.boot.growup.auth.persist.entity.Customer;
+import org.boot.growup.auth.persist.entity.Seller;
 import org.boot.growup.common.constant.ErrorCode;
 import org.boot.growup.common.constant.PayMethod;
 import org.boot.growup.common.model.BaseException;
 import org.boot.growup.order.dto.OrderDTO;
+import org.boot.growup.order.dto.request.PatchShipmentRequestDTO;
+import org.boot.growup.order.persist.entity.Delivery;
 import org.boot.growup.order.persist.entity.Order;
 import org.boot.growup.order.persist.entity.OrderItem;
+import org.boot.growup.order.persist.repository.OrderItemRepository;
 import org.boot.growup.order.persist.repository.OrderRepository;
 import org.boot.growup.order.service.OrderService;
 import org.boot.growup.product.persist.entity.ProductOption;
@@ -15,10 +20,12 @@ import org.springframework.stereotype.Service;
 
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
 
     @Override
     public Order processNormalOrder(OrderDTO orderDTO, Map<ProductOption, Integer> productOptionCountMap, Customer customer) {
@@ -40,7 +47,7 @@ public class OrderServiceImpl implements OrderService {
         Order order = orderRepository.findByMerchantUidAndCustomer(merchantUid, customer)
                 .orElseThrow(() -> new BaseException(ErrorCode.ORDER_NOT_FOUND));
 
-        // 2. 해당 Order 객체 내 OrderItem들을 모두 Payed 상태로 변경.
+        // 2. 해당 Order 객체 내 OrderItem들을 모두 Payed 상태로 변경 및 OrderItem당 수수료 및 판매정산금 계산
         order.getOrderItems().forEach(OrderItem::payed);
 
         // 3. Order 객체 저장
@@ -60,11 +67,104 @@ public class OrderServiceImpl implements OrderService {
         orderRepository.save(order);
     }
 
+    @Override
+    public void preshippedOrder(Long orderItemId, Seller seller) {
+        // 1. orderItemId 및 Seller로 OrderItem 조회
+        OrderItem orderItem = orderItemRepository.findByIdAndSellerId(orderItemId, seller.getId())
+                                    .orElseThrow(() -> new BaseException(ErrorCode.ORDER_ITEM_NOT_FOUND));
+
+
+        log.info("orderItem -> {}", orderItem.getOrderStatus());
+        // 2. preshipped() 상태로 변경
+        orderItem.preShipped();
+
+        // 3. OrderItem 객체 저장
+        orderItemRepository.save(orderItem);
+    }
+
+    @Override
+    public void shippedOrder(Long orderItemId, Seller seller) {
+        // 1. orderItemId 및 Seller로 OrderItem 조회
+        OrderItem orderItem = orderItemRepository.findByIdAndSellerId(orderItemId, seller.getId())
+                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_ITEM_NOT_FOUND));
+
+        // 2. shipped() 상태로 변경
+        orderItem.shipped();
+
+        // 3. OrderItem 객체 저장
+        orderItemRepository.save(orderItem);
+    }
+
+    @Override
+    public void shipmentOrder(Long orderItemId, Seller seller, PatchShipmentRequestDTO patchShipmentRequestDTO) {
+        // 1. orderItemId 및 Seller로 OrderItem 조회
+        OrderItem orderItem = orderItemRepository.findByIdAndSellerId(orderItemId, seller.getId())
+                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_ITEM_NOT_FOUND));
+
+        // 2. Delivery 객체 생성
+        Delivery delivery = Delivery.of(patchShipmentRequestDTO, orderItem);
+
+        // 3. shipment() 상태로 변경 및 배송 정보 설정
+        orderItem.shipment(delivery);
+
+        // 4. OrderItem 객체 저장
+        orderItemRepository.save(orderItem);
+    }
+
+    @Override
+    public void transitOrder(Long orderItemId, Seller seller) {
+        // 1. orderItemId 및 Seller로 OrderItem 조회
+        OrderItem orderItem = orderItemRepository.findByIdAndSellerId(orderItemId, seller.getId())
+                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_ITEM_NOT_FOUND));
+
+        // 2. transit() 상태로 변경
+        orderItem.transit();
+
+        // 3. OrderItem 객체 저장
+        orderItemRepository.save(orderItem);
+    }
+
+    @Override
+    public void arrivedOrder(Long orderItemId, Seller seller) {
+        // 1. orderItemId 및 Seller로 OrderItem 조회
+        OrderItem orderItem = orderItemRepository.findByIdAndSellerId(orderItemId, seller.getId())
+                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_ITEM_NOT_FOUND));
+
+        // 2. arrived() 상태로 변경
+        orderItem.arrived();
+
+        // 3. OrderItem 객체 저장
+        orderItemRepository.save(orderItem);
+    }
+
+    @Override
+    public void confirmedPurchaseOrder(String merchantUid, Long orderItemId, Customer customer) {
+        // 0. customer + merchantUid로 order 조회
+        Order order = orderRepository.findByMerchantUidAndCustomer(merchantUid, customer)
+                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 1. orderItemId 및 현재 Customer의 OrderId로 OrderItem 조회
+        OrderItem orderItem = orderItemRepository.findByIdAndOrderId(orderItemId, order.getId())
+                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_ITEM_NOT_FOUND));
+
+        // 3. PURCHASE_CONFIRM() 상태로 변경
+        orderItem.confirmedPurchase();
+
+        // 4. OrderItem 객체 저장
+        orderItemRepository.save(orderItem);
+    }
+
+    @Override
+    public Order getOrder(String merchantUid, Customer customer) {
+        return orderRepository.findByMerchantUidAndCustomer(merchantUid, customer)
+                .orElseThrow(() -> new BaseException(ErrorCode.ORDER_NOT_FOUND));
+    }
+
     private void place(Map<ProductOption, Integer> productOptionCountMap, Order order) {
         // 1. 주문상품의 허가상태 확인 및 주문상품옵션 재고 확인
         validate(productOptionCountMap);
 
-        // 2. PRE_PAYED 상태의 orderItem 생성, 상품옵션 재고량 감소 및 총주문금액 계산
+        // 2. PRE_PAID 상태의 orderItem 생성, 상품옵션 재고량 감소 및 총주문금액 계산
         ordered(productOptionCountMap, order);
     }
 
@@ -75,7 +175,7 @@ public class OrderServiceImpl implements OrderService {
     private void ordered(Map<ProductOption, Integer> productOptionCountMap, Order order) {
         productOptionCountMap.forEach((option, count) -> {
             OrderItem orderItem = OrderItem.of(option, count); // orderItem들을 만듦.
-            orderItem.prePayed(); // orderItem들을 PRE_PAYED로 변경
+            orderItem.prePaid(); // orderItem들을 PRE_PAID로 변경
             option.decreaseStock(count); // productoption n개 만큼 재고량 감소시킴.
             orderItem.ordered(order); // 총주문금액 계산 ('개별상품 배송비 + 개별 상품옵션 가격*수량'들의 총합) 및 order 객체에 연결
         });


### PR DESCRIPTION
## 변경사항
### AS-IS
- Seller 주문항목 PAID -> PRE-SHIPPED로 상태 변경 API
- Seller 주문항목 PAID, PRE-SHIPPED -> SHIPPED로 상태 변경 API
- Seller 주문항목 SHIPPED -> PENDING_SHIPMENT로 상태 변경 API
- Seller 주문항목 PENDING_SHIPMENT -> IN_TRANSIT로 상태 변경 API
- Seller 주문항목 IN_TRANSIT -> ARRIVED로 상태 변경 API
- Customer 구매 확정 상태로 변경 API
- Customer 주문 조회 API
- Dataloader에 Order 및 OrderItem 추가
- Delivery-OrderItem 일대일 관계로 변경
- ErrorCode 추가
- 수수료 및 판매정산금 연산 로직 추가
- OrderItem 엔티티에 수수료 및 정산금 필드 추가
- PAYED -> PAID로 오타 수정

### TO-BE
- 테스트 코드 작성 필요
- 환불 로직 작성 필요
- Admin의 balance를 계산할 방법 필요
- 배송조회로직 작성 필요
- 그로우페이 결제 필요

## 테스트
- [ ] 테스트 코드
- [x] API 테스트