### PR TITLE
Feature/order/order 주문번호 요청, 결제 성공 사실 알림 API 로직 수정, 구매자의 주문 내역 목록 조회 API

### DIFF
--- a/src/main/java/org/boot/growup/common/constant/ErrorCode.java
+++ b/src/main/java/org/boot/growup/common/constant/ErrorCode.java
@@ -87,6 +87,7 @@ public enum ErrorCode {
     /* Order 관련 */
     ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, 404, false, "해당 주문을 찾을 수 없습니다."),
     ORDER_ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, 404, false, "해당 주문항목을 찾을 수 없습니다."),
+    PAY_PRICE_DIFFER_ORDER_PRICE(HttpStatus.CONFLICT, 409, false, "결제금액과 주문금액이 서로 다릅니다."),
     PAY_NOT_SUCCESS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문의 결제 사실을 확인할 수 없습니다."),
     PAY_ALREADY_SUCCESS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문의 결제는 성공했습니다."),
     ORDER_ITEM_NOT_PAID_STATUS(HttpStatus.BAD_REQUEST, 404, false, "해당 주문 항목은 PAID 상태가 아닙니다."),

--- a/src/main/java/org/boot/growup/common/utils/DataLoader.java
+++ b/src/main/java/org/boot/growup/common/utils/DataLoader.java
@@ -101,6 +101,8 @@ public class DataLoader {
         preshippedOrderItem1.payed();
         preshippedOrderItem1.preShipped();
 
+        order1.designateName();
+
         orderRepository.save(order1);
     }
 

--- a/src/main/java/org/boot/growup/order/application/OrderApplication.java
+++ b/src/main/java/org/boot/growup/order/application/OrderApplication.java
@@ -16,6 +16,7 @@ import org.boot.growup.order.dto.PortOnePaymentDTO;
 import org.boot.growup.order.dto.request.PatchShipmentRequestDTO;
 import org.boot.growup.order.dto.request.PortOnePaymentCancellationRequestDTO;
 import org.boot.growup.order.dto.request.ProcessNormalOrderRequestDTO;
+import org.boot.growup.order.dto.response.GetOrderHistoryResponseDTO;
 import org.boot.growup.order.dto.response.GetOrderResponseDTO;
 import org.boot.growup.order.dto.response.ProcessNormalOrderResponseDTO;
 import org.boot.growup.order.persist.entity.Order;
@@ -23,6 +24,7 @@ import org.boot.growup.order.service.OrderService;
 import org.boot.growup.product.persist.entity.ProductOption;
 import org.boot.growup.product.service.ProductService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -154,5 +156,13 @@ public class OrderApplication {
         Order order = orderService.getOrder(merchantUid, customer);
 
         return GetOrderResponseDTO.from(order);
+    }
+
+    public Page<GetOrderHistoryResponseDTO> getOrderHistory(int pageNo) {
+        Customer customer = customerService.getCurrentCustomer();
+
+        Page<Order> orders = orderService.getOrders(customer, pageNo);
+
+        return GetOrderHistoryResponseDTO.pageFrom(orders);
     }
 }

--- a/src/main/java/org/boot/growup/order/client/PortOneFeignClient.java
+++ b/src/main/java/org/boot/growup/order/client/PortOneFeignClient.java
@@ -1,11 +1,10 @@
 package org.boot.growup.order.client;
 
+import org.boot.growup.order.dto.PortOnePaymentCancellationDTO;
 import org.boot.growup.order.dto.PortOnePaymentDTO;
+import org.boot.growup.order.dto.request.PortOnePaymentCancellationRequestDTO;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @FeignClient(name = "portOneFeignClient", url = "https://api.portone.io")
 public interface PortOneFeignClient {
@@ -17,5 +16,15 @@ public interface PortOneFeignClient {
             @PathVariable("paymentId") String paymentId,
             @RequestParam("storeId") String storeId,
             @RequestHeader("Authorization") String authorizationHeader
+    );
+
+    /*
+    PortOne에 결제 취소를 요청함.
+     */
+    @PostMapping(value = "/payments/{paymentId}/cancel")
+    PortOnePaymentCancellationDTO cancelPaymentByPaymentId(
+            @PathVariable("paymentId") String paymentId,
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody PortOnePaymentCancellationRequestDTO dto
     );
 }

--- a/src/main/java/org/boot/growup/order/controller/CustomerOrderController.java
+++ b/src/main/java/org/boot/growup/order/controller/CustomerOrderController.java
@@ -7,6 +7,7 @@ import org.boot.growup.common.model.BaseResponse;
 import org.boot.growup.order.application.OrderApplication;
 import org.boot.growup.order.dto.request.ProcessNormalOrderRequestDTO;
 import org.boot.growup.order.dto.response.GetOrderResponseDTO;
+import org.boot.growup.order.dto.response.ProcessNormalOrderResponseDTO;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -24,7 +25,7 @@ public class CustomerOrderController {
      * @response merchantUid
      */
     @PostMapping("/payments/process")
-    public BaseResponse<String> processNormalOrder(@Valid @RequestBody ProcessNormalOrderRequestDTO form) {
+    public BaseResponse<ProcessNormalOrderResponseDTO> processNormalOrder(@Valid @RequestBody ProcessNormalOrderRequestDTO form) {
         form.getOrderItemDTOs().forEach(m -> log.info(String.valueOf(m.getProductOptionId())));
         return new BaseResponse<>(orderApplication.processNormalOrder(form));
     }

--- a/src/main/java/org/boot/growup/order/controller/CustomerOrderController.java
+++ b/src/main/java/org/boot/growup/order/controller/CustomerOrderController.java
@@ -6,8 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.boot.growup.common.model.BaseResponse;
 import org.boot.growup.order.application.OrderApplication;
 import org.boot.growup.order.dto.request.ProcessNormalOrderRequestDTO;
+import org.boot.growup.order.dto.response.GetOrderHistoryResponseDTO;
 import org.boot.growup.order.dto.response.GetOrderResponseDTO;
 import org.boot.growup.order.dto.response.ProcessNormalOrderResponseDTO;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -78,9 +80,19 @@ public class CustomerOrderController {
         return new BaseResponse<>(orderApplication.getOrder(merchantUid));
     }
 
+    /**
+     * [GET]
+     * 구매자의 주문 내역 목록 조회
+     * @header CustomerAccesstoken
+     * @param pageNo 페이지번호
+     * @return Page<GetOrderHistoryResponseDTO>
+     */
+    @GetMapping("/history")
+    public BaseResponse<Page<GetOrderHistoryResponseDTO>> getOrderHistory(
+            @RequestParam(value = "pageNo", defaultValue = "0") int pageNo
+    ){
+        return new BaseResponse<>(orderApplication.getOrderHistory(pageNo));
+    }
     // 환불 요청
-
-    // 배송 조회
-
     // 그로우페이 결제
 }

--- a/src/main/java/org/boot/growup/order/dto/PortOnePaymentCancellationDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/PortOnePaymentCancellationDTO.java
@@ -1,0 +1,16 @@
+package org.boot.growup.order.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PortOnePaymentCancellationDTO {
+    private String status;
+    private String id;
+    private int totalAmount;
+    private int taxFreeAmount;
+    private int vatAmount;
+    private String reason; // 취소 사유
+    private String receiptUrl; // 취소 영수증 URL
+}

--- a/src/main/java/org/boot/growup/order/dto/PortOnePaymentDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/PortOnePaymentDTO.java
@@ -21,6 +21,7 @@ public class PortOnePaymentDTO {
     private PaymentCancellation[] Cancellations;
     private String cancelledAt; // 결제 취소 시점
 
+    @Data
     public static class PayAmount{
         private int total; // 총 결제금액
         private int taxFree; // 면세액
@@ -30,6 +31,7 @@ public class PortOnePaymentDTO {
         private int cancelledTaxFree; // 취소금액 중 면세액
     }
 
+    @Data
     public static class PaymentCancellation{
         private String status; // 결제 취소 상태
         private String id;

--- a/src/main/java/org/boot/growup/order/dto/request/PortOnePaymentCancellationRequestDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/request/PortOnePaymentCancellationRequestDTO.java
@@ -1,0 +1,11 @@
+package org.boot.growup.order.dto.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class PortOnePaymentCancellationRequestDTO {
+    private String storeId;
+    private String reason;
+}

--- a/src/main/java/org/boot/growup/order/dto/response/GetOrderHistoryResponseDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/response/GetOrderHistoryResponseDTO.java
@@ -1,0 +1,40 @@
+package org.boot.growup.order.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import org.boot.growup.order.persist.entity.Order;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class GetOrderHistoryResponseDTO {
+    private String merchantUid;
+    private int totalPrice;
+    private String receiverName;
+    private String receiverAddress;
+    private String receiverPostCode;
+    private String receiverPhone;
+    private String orderName;
+    private String message;
+    private LocalDateTime createAt;
+
+    public static Page<GetOrderHistoryResponseDTO> pageFrom(Page<Order> orders) {
+        return orders.map(GetOrderHistoryResponseDTO::from);
+    }
+
+    private static GetOrderHistoryResponseDTO from(Order order) {
+        return GetOrderHistoryResponseDTO.builder()
+                .merchantUid(order.getMerchantUid())
+                .totalPrice(order.getTotalPrice())
+                .receiverName(order.getReceiverName())
+                .receiverAddress(order.getReceiverAddress())
+                .receiverPostCode(order.getReceiverPostCode())
+                .receiverPhone(order.getReceiverPhone())
+                .orderName(order.getName())
+                .message(order.getMessage())
+                .createAt(order.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/boot/growup/order/dto/response/GetOrderItemResponseDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/response/GetOrderItemResponseDTO.java
@@ -3,7 +3,9 @@ package org.boot.growup.order.dto.response;
 import lombok.Builder;
 import lombok.Data;
 import org.boot.growup.common.constant.OrderStatus;
+import org.boot.growup.order.persist.entity.Delivery;
 import org.boot.growup.order.persist.entity.OrderItem;
+import org.springframework.util.ObjectUtils;
 
 @Data
 @Builder
@@ -15,16 +17,25 @@ public class GetOrderItemResponseDTO {
     private String productName;
     private String productOptionName;
     private int productOptionPrice;
+    private int carrierCode;
+    private String trackNumber;
 
-    public static GetOrderItemResponseDTO from(OrderItem orderItem) {
-        return GetOrderItemResponseDTO.builder()
-                .id(orderItem.getId())
-                .count(orderItem.getCount())
-                .orderStatus(orderItem.getOrderStatus())
-                .deliveryFee(orderItem.getDeliveryFee())
-                .productName(orderItem.getProductName())
-                .productOptionName(orderItem.getProductOptionName())
-                .productOptionPrice(orderItem.getProductOptionPrice())
-                .build();
+    public static GetOrderItemResponseDTO of(OrderItem orderItem, Delivery delivery) {
+        GetOrderItemResponseDTOBuilder builder = GetOrderItemResponseDTO.builder()
+                                                .id(orderItem.getId())
+                                                .count(orderItem.getCount())
+                                                .orderStatus(orderItem.getOrderStatus())
+                                                .deliveryFee(orderItem.getDeliveryFee())
+                                                .productName(orderItem.getProductName())
+                                                .productOptionName(orderItem.getProductOptionName())
+                                                .productOptionPrice(orderItem.getProductOptionPrice());
+
+        if (ObjectUtils.isEmpty(delivery)) {
+            return builder.build();
+        }
+
+        return builder.carrierCode(delivery.getCarrierCode())
+                        .trackNumber(delivery.getTrackingNumber())
+                        .build();
     }
 }

--- a/src/main/java/org/boot/growup/order/dto/response/GetOrderResponseDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/response/GetOrderResponseDTO.java
@@ -29,7 +29,7 @@ public class GetOrderResponseDTO {
                 .receiverPhone(order.getReceiverPhone())
                 .receiverPostCode(order.getReceiverPostCode())
                 .orderItems(order.getOrderItems().stream()
-                        .map(GetOrderItemResponseDTO::from)
+                        .map(oi -> GetOrderItemResponseDTO.of(oi, oi.getDelivery()))
                         .toList()
                 )
                 .build();

--- a/src/main/java/org/boot/growup/order/dto/response/ProcessNormalOrderResponseDTO.java
+++ b/src/main/java/org/boot/growup/order/dto/response/ProcessNormalOrderResponseDTO.java
@@ -1,0 +1,32 @@
+package org.boot.growup.order.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import org.boot.growup.auth.persist.entity.Customer;
+import org.boot.growup.order.persist.entity.Order;
+
+@Data
+@Builder
+public class ProcessNormalOrderResponseDTO {
+    private String merchantUid;
+    private String orderName;
+    private int totalPrice;
+    private String currency;
+    private String payMethod;
+    private String fullName;
+    private String phoneNumber;
+    private String email;
+
+    public static ProcessNormalOrderResponseDTO of(Order order, Customer customer) {
+        return ProcessNormalOrderResponseDTO.builder()
+                .merchantUid(order.getMerchantUid())
+                .orderName(order.getName())
+                .totalPrice(order.getTotalPrice())
+                .currency("CURRENCY_KRW")
+                .payMethod("CARD")
+                .fullName(customer.getName())
+                .phoneNumber(customer.getPhoneNumber())
+                .email(customer.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/org/boot/growup/order/persist/entity/Order.java
+++ b/src/main/java/org/boot/growup/order/persist/entity/Order.java
@@ -8,8 +8,10 @@ import lombok.NoArgsConstructor;
 import org.boot.growup.auth.persist.entity.Customer;
 import org.boot.growup.common.constant.ErrorCode;
 import org.boot.growup.common.constant.PayMethod;
+import org.boot.growup.common.entity.BaseEntity;
 import org.boot.growup.common.model.BaseException;
 import org.boot.growup.order.dto.OrderDTO;
+import org.hibernate.envers.AuditOverride;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -20,7 +22,8 @@ import java.util.*;
 @Table(name = "orders")
 @NoArgsConstructor
 @AllArgsConstructor
-public class Order {
+@AuditOverride(forClass = BaseEntity.class)
+public class Order extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "order_id", nullable = false)

--- a/src/main/java/org/boot/growup/order/persist/entity/Order.java
+++ b/src/main/java/org/boot/growup/order/persist/entity/Order.java
@@ -6,7 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.boot.growup.auth.persist.entity.Customer;
+import org.boot.growup.common.constant.ErrorCode;
 import org.boot.growup.common.constant.PayMethod;
+import org.boot.growup.common.model.BaseException;
 import org.boot.growup.order.dto.OrderDTO;
 
 import java.text.SimpleDateFormat;
@@ -23,6 +25,9 @@ public class Order {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "order_id", nullable = false)
     private Long id;
+
+    @Column(nullable = false, length = 25)
+    private String name;
 
     @Column(nullable = false, length = 18)
     private String merchantUid;
@@ -86,4 +91,14 @@ public class Order {
         this.totalPrice += orderItemPrice;
     }
 
+    public void designateName() {
+        if (orderItems.isEmpty()) {
+            throw new BaseException(ErrorCode.ORDER_ITEM_NOT_FOUND);
+        }
+
+        int itemCount = orderItems.size();
+        String firstProductName = orderItems.get(0).getProductName();
+
+        this.name = String.format("%s 외 %d건", firstProductName, itemCount);
+    }
 }

--- a/src/main/java/org/boot/growup/order/persist/entity/OrderCancel.java
+++ b/src/main/java/org/boot/growup/order/persist/entity/OrderCancel.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.boot.growup.common.entity.BaseEntity;
+import org.hibernate.envers.AuditOverride;
 
 @Entity
 @Getter
@@ -12,7 +14,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "order_cancel")
 @NoArgsConstructor
 @AllArgsConstructor
-public class OrderCancel {
+@AuditOverride(forClass = BaseEntity.class)
+public class OrderCancel extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "order_cancel_id", nullable = false)

--- a/src/main/java/org/boot/growup/order/persist/entity/OrderItem.java
+++ b/src/main/java/org/boot/growup/order/persist/entity/OrderItem.java
@@ -10,9 +10,11 @@ import org.boot.growup.auth.persist.entity.Seller;
 import org.boot.growup.common.constant.Commission;
 import org.boot.growup.common.constant.ErrorCode;
 import org.boot.growup.common.constant.OrderStatus;
+import org.boot.growup.common.entity.BaseEntity;
 import org.boot.growup.common.model.BaseException;
 import org.boot.growup.product.persist.entity.Product;
 import org.boot.growup.product.persist.entity.ProductOption;
+import org.hibernate.envers.AuditOverride;
 
 import java.time.LocalDateTime;
 
@@ -23,7 +25,8 @@ import java.time.LocalDateTime;
 @Table(name = "order_item")
 @NoArgsConstructor
 @AllArgsConstructor
-public class OrderItem {
+@AuditOverride(forClass = BaseEntity.class)
+public class OrderItem extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "order_item_id", nullable = false)

--- a/src/main/java/org/boot/growup/order/persist/repository/OrderRepository.java
+++ b/src/main/java/org/boot/growup/order/persist/repository/OrderRepository.java
@@ -2,10 +2,13 @@ package org.boot.growup.order.persist.repository;
 
 import org.boot.growup.auth.persist.entity.Customer;
 import org.boot.growup.order.persist.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByMerchantUidAndCustomer(String merchantUid, Customer customer);
+    Page<Order> findByCustomer(Customer customer, Pageable pageable);
 }

--- a/src/main/java/org/boot/growup/order/service/OrderService.java
+++ b/src/main/java/org/boot/growup/order/service/OrderService.java
@@ -6,6 +6,7 @@ import org.boot.growup.order.dto.OrderDTO;
 import org.boot.growup.order.dto.request.PatchShipmentRequestDTO;
 import org.boot.growup.order.persist.entity.Order;
 import org.boot.growup.product.persist.entity.ProductOption;
+import org.springframework.data.domain.Page;
 
 import java.util.Map;
 
@@ -59,4 +60,9 @@ public interface OrderService {
     merchantUid와 customer 정보로 Order를 가져옴.
      */
     Order getOrder(String merchantUid, Customer customer);
+
+    /*
+    현재 customer의 order들을 페이징처리하여 가져옴.
+     */
+    Page<Order> getOrders(Customer customer, int pageNo);
 }

--- a/src/main/java/org/boot/growup/order/service/OrderService.java
+++ b/src/main/java/org/boot/growup/order/service/OrderService.java
@@ -16,9 +16,9 @@ public interface OrderService {
     Order processNormalOrder(OrderDTO orderDTO, Map<ProductOption, Integer> productOptionCountMap, Customer customer);
 
     /*
-    주문번호 + 구매자 정보를 통해 Order를 찾고, OrderItem들을 PAYED 상태로 변경 및 수수료, 정산금을 계산함.
+    주문번호 + 구매자 정보를 통해 Order를 찾고, 실제 결제 금액과 일치하는지 확인 후, OrderItem들을 PAYED 상태로 변경 및 수수료, 정산금을 계산함.
      */
-    void completeOrder(String merchantUid, Customer customer);
+    void completeOrder(String merchantUid, Customer customer, int totalPrice);
 
     /*
     주문번호 + 구매자 정보를 통해 Order를 찾고, OrderItem들을 REJECTED 상태로 변경함.

--- a/src/main/java/org/boot/growup/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/org/boot/growup/order/service/impl/OrderServiceImpl.java
@@ -16,6 +16,9 @@ import org.boot.growup.order.persist.repository.OrderItemRepository;
 import org.boot.growup.order.persist.repository.OrderRepository;
 import org.boot.growup.order.service.OrderService;
 import org.boot.growup.product.persist.entity.ProductOption;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -163,6 +166,13 @@ public class OrderServiceImpl implements OrderService {
     public Order getOrder(String merchantUid, Customer customer) {
         return orderRepository.findByMerchantUidAndCustomer(merchantUid, customer)
                 .orElseThrow(() -> new BaseException(ErrorCode.ORDER_NOT_FOUND));
+    }
+
+    @Override
+    public Page<Order> getOrders(Customer customer, int pageNo) {
+        Pageable pageable = PageRequest.of(pageNo, 10);
+
+        return orderRepository.findByCustomer(customer, pageable);
     }
 
     private void place(Map<ProductOption, Integer> productOptionCountMap, Order order) {

--- a/src/main/resources/templates/test-payv2.html
+++ b/src/main/resources/templates/test-payv2.html
@@ -13,8 +13,34 @@
         // https://developers.portone.io/docs/ko/authpay/guide?v=v2
         // 장바구니 상품 정보 보내기 및 주문번호 요청
 
-        var customerToken = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjdXN0b21lcjEyM0BuYXZlci5jb20iLCJhdXRoIjoiUk9MRV9DVVNUT01FUiIsImlhdCI6MTcyNDY2NTYwNCwiZXhwIjoxNzI0NjY5MjA0fQ.WKELJczp67a63Xxn8VIrao3nOVjPhPcye9rcA6tqjZw";
+        var customerToken = "";
         var merchantUid = ""; // 주문번호 입력
+        var resOrderName = "";
+        var resTotalAmount = 0;
+        var resCurrency = "";
+        var resPayMethod = "";
+        var resFullName = "";
+        var resPhoneNumber = "";
+        var resEmail = "";
+
+        function login(){
+            var settings = {
+                "url": "http://localhost:8081/customers/email/login",
+                "method": "POST",
+                "timeout": 0,
+                "headers": {
+                    "Content-Type": "application/json"
+                },
+                "data": JSON.stringify({
+                    "email": "customer123@naver.com",
+                    "password": "!a123456789"
+                }),
+            };
+            $.ajax(settings).done(function (response){
+                customerToken = response.data.grantType + " " + response.data.accessToken;
+                console.log(customerToken);
+            });
+        }
 
         function requestOrderNumber(){
             var settings = {
@@ -56,7 +82,20 @@
 
             $.ajax(settings).done(function (response) {
                 console.log(response);
-                merchantUid = response.data;
+                merchantUid = response.data.merchantUid;
+                resOrderName = response.data.orderName;
+                resTotalAmount = response.data.totalPrice;
+                resCurrency = response.data.currency;
+                resPayMethod = response.data.payMethod;
+                resFullName = response.data.fullName;
+                resPhoneNumber = response.data.phoneNumber;
+                resEmail = response.data.email;
+
+                $("#merchantUid").text(merchantUid);
+                $("#resOrderName").text(resOrderName);
+                $("#resTotalAmount").text(resTotalAmount + "원");
+
+                console.log(merchantUid);
             });
         }
 
@@ -67,19 +106,18 @@
                 storeId: "store-8c062e98-d009-4b6d-9344-8cd2349938a2",
                 // 채널 키 설정
                 channelKey: "channel-key-86882cda-8e2c-4ef8-895d-a6fa29a8876e",
-                paymentId: merchantUid,
-                orderName: "주문01",
-                totalAmount: 1000,
-                currency: "CURRENCY_KRW",
-                payMethod: "CARD",
+                paymentId: `${merchantUid}`,
+                orderName: `${resOrderName}`,
+                totalAmount: `${resTotalAmount}`,
+                currency: `${resCurrency}`,
+                payMethod: `${resPayMethod}`,
                 customer: {
-                    customerId: "1",
-                    fullName: "정태승",
-                    phoneNumber: "01084204241",
-                    email: "hi563@naver.com",
+                    fullName: `${resFullName}`,
+                    phoneNumber: `${resPhoneNumber}`,
+                    email: `${resEmail}`,
 
                 },
-                redirectUrl: "http://localhost:8081/login/testorder"
+                // redirectUrl: "http://localhost:8081/login/testorder"
             });
 
             if(response.code != null){
@@ -115,31 +153,24 @@
                 if (!response.ok) {
                     throw new Error("Network response was not ok");
                 }
-                return response.json(); // JSON 응답을 파싱
-            })
-                .then(data => {
-                    $("#success").text("결제성공! 위 정보가 WAITING 상태입니다.");
-                    alert("결제 성공했습니다!");
-                })
-                .catch(error => {
-                    console.error("There was a problem with the fetch operation:", error);
-                    alert("결제 실패했습니다. 다시 시도해주세요.");
-                });
+                $("#success").text("결제성공! 위 정보가 PAID 상태입니다.");
+                alert("결제 성공했습니다!");
+            }).catch(error => {
+                console.error("There was a problem with the fetch operation:", error);
+                alert("결제 실패했습니다. 다시 시도해주세요.");
+            });
         }
     </script>
     <meta charset="UTF-8"/>
     <title>Sample Payment</title>
 </head>
 <body>
-<button onclick="requestOrderNumber()">테스트버튼</button>
-<div id="pre"></div>
-<div id="orderId"></div>
-<div id="orderNumber"></div>
-<div id="totalPrice"></div>
+<button onclick="login()">구매자이메일로그인</button>
+<button onclick="requestOrderNumber()">주문번호생성</button>
+<div id="merchantUid"></div>
+<div id="resOrderName"></div>
+<div id="resTotalAmount"></div>
 <button onclick="requestPay()">결제하기</button>
 <div id="success"></div>
-<div id="orderId2"></div>
-<div id="orderNumber2"></div>
-<div id="totalPrice2"></div>
 </body>
 </html>


### PR DESCRIPTION
## 변경사항
### AS-IS
- 결제 성공 사실 알림 API에서, 해당 결제 정보가 주문번호로 포트원 API에 요청해 결제 금액과 주문 금액이 일치하는지 확인.
- Order에 주문이름 필드 추가 및 주문이름 생성 메소드 추가
- PortOneFeignClient 결제 취소 API 추가
- test-payv2.html 자동 로그인 버튼 추가 및 결제요청 가능
- 주문 단일 내역 조회 시, 운송장번호와 택배사 코드도 나타나도록 수정
- Order, OrderCancel, OrderItem BaseEntity를 상속받도록 수정

### TO-BE
- 환불 기능 추가 필요
- 그로우페이 결제 기능 추가 필요

## 테스트
- [ ] 테스트 코드
- [x] API 테스트